### PR TITLE
Avoid previous symbols replacing mapping of current symbols

### DIFF
--- a/common/HGNCParser.py
+++ b/common/HGNCParser.py
@@ -101,5 +101,6 @@ class GeneParser(object):
             if 'prev_symbol' in row:
                 # to handle obsolete gene symbols like EFCAB4B
                 for prev_symbol in row['prev_symbol']:
-                    self.genes[prev_symbol] = ensembl_gene_id
+                    if prev_symbol not in self.genes:
+                        self.genes[prev_symbol] = ensembl_gene_id
         logger.info('All HGNC genes parsed')


### PR DESCRIPTION
Improve current implementation, where it is possible that the mapping of a current gene symbol to Ensembl id is replaced by a previous symbol. For example, `TCF4` is both the symbol of `ENSG00000196628` and a synonym of `TCF7L2 - ENSG00000148737` and the current implementation maps `TCF4` to `ENSG00000148737`. This PR adds a test so that mappings of previous symbols are only stored if they don't already exist. 