### PR TITLE
Ag g2p jsonschema objects

### DIFF
--- a/common/RareDiseasesUtils.py
+++ b/common/RareDiseasesUtils.py
@@ -27,7 +27,7 @@ class RareDiseaseMapper(object):
             omim	efo_uri	efo_label	source	status
             '''
             line_count += 1
-            (omim, efo_uri, efo_label, source, status) = line.split("\t")
+            (omim, efo_uri, efo_label) = line.split("\t")
             if omim not in self.omim_to_efo_map:
                 self.omim_to_efo_map[omim] = []
             self.omim_to_efo_map[omim].append({'efo_uri': efo_uri, 'efo_label': efo_label})

--- a/modules/Gene2Phenotype.py
+++ b/modules/Gene2Phenotype.py
@@ -99,70 +99,70 @@ class G2P(RareDiseaseMapper):
                                     }
                                 }
 
-                            # *** General properties ***
-                            access_level = "public"
-                            sourceID = "gene2phenotype"
-                            validated_against_schema_version = Config.VALIDATED_AGAINST_SCHEMA_VERSION
+                                # *** General properties ***
+                                access_level = "public"
+                                sourceID = "gene2phenotype"
+                                validated_against_schema_version = Config.VALIDATED_AGAINST_SCHEMA_VERSION
 
-                            # *** Target info ***
-                            target = {
-                                'id' : ensembl_iri,
-                                'activity' : "http://identifiers.org/cttv.activity/unknown",
-                                'target_type' : "http://identifiers.org/cttv.target/gene_evidence",
-                                'target_name' : gene_symbol
-                            }
-                            # http://www.ontobee.org/ontology/ECO?iri=http://purl.obolibrary.org/obo/ECO_0000204 -- An evidence type that is based on an assertion by the author of a paper, which is read by a curator.
-
-                            # *** Disease info ***
-                            disease_info = {
-                                'id' : disease['efo_uri'],
-                                'name' : disease['efo_label'],
-                                'source_name' : disease_name
-                            }
-                            # *** Evidence info ***
-                            resource_score = {
-                                'type' : "probability",
-                                'value' : 1
-                            }
-                            # Linkout
-                            linkout = [
-                                {
-                                    'url' : 'http://www.ebi.ac.uk/gene2phenotype/search?panel=ALL&search_term=%s' % (gene_symbol,),
-                                    'nice_name' : 'Gene2Phenotype%s' % (gene_symbol)
+                                # *** Target info ***
+                                target = {
+                                    'id' : ensembl_iri,
+                                    'activity' : "http://identifiers.org/cttv.activity/unknown",
+                                    'target_type' : "http://identifiers.org/cttv.target/gene_evidence",
+                                    'target_name' : gene_symbol
                                 }
-                            ]
+                                # http://www.ontobee.org/ontology/ECO?iri=http://purl.obolibrary.org/obo/ECO_0000204 -- An evidence type that is based on an assertion by the author of a paper, which is read by a curator.
 
-                            evidence = {
-                                'is_associated' : True,
-                                'evidence_codes' : ["http://purl.obolibrary.org/obo/ECO_0000204"],
-                                'provenance_type' : provenance_type,
-                                'date_asserted' : datetime.datetime(2020, 4, 2, 0, 0).isoformat(),
-                                'resource_score' : resource_score,
-                                'urls' : linkout
-                            }
-                            # *** unique_association_fields ***
-                            unique_association_fields = {
-                                'target_id' : ensembl_iri,
-                                'original_disease_label' : disease_name,
-                                'disease_id' : disease['efo_uri']
-                            }
+                                # *** Disease info ***
+                                disease_info = {
+                                    'id' : disease['efo_uri'],
+                                    'name' : disease['efo_label'],
+                                    'source_name' : disease_name
+                                }
+                                # *** Evidence info ***
+                                resource_score = {
+                                    'type' : "probability",
+                                    'value' : 1
+                                }
+                                # Linkout
+                                linkout = [
+                                    {
+                                        'url' : 'http://www.ebi.ac.uk/gene2phenotype/search?panel=ALL&search_term=%s' % (gene_symbol,),
+                                        'nice_name' : 'Gene2Phenotype%s' % (gene_symbol)
+                                    }
+                                ]
+
+                                evidence = {
+                                    'is_associated' : True,
+                                    'evidence_codes' : ["http://purl.obolibrary.org/obo/ECO_0000204"],
+                                    'provenance_type' : provenance_type,
+                                    'date_asserted' : datetime.datetime(2020, 4, 2, 0, 0).isoformat(),
+                                    'resource_score' : resource_score,
+                                    'urls' : linkout
+                                }
+                                # *** unique_association_fields ***
+                                unique_association_fields = {
+                                    'target_id' : ensembl_iri,
+                                    'original_disease_label' : disease_name,
+                                    'disease_id' : disease['efo_uri']
+                                }
 
 
-                            try:
-                                evidence = self.evidence_builder.Opentargets(
-                                    type = type,
-                                    access_level = access_level,
-                                    sourceID = sourceID,
-                                    evidence = evidence,
-                                    target = target,
-                                    disease = disease_info,
-                                    unique_association_fields = unique_association_fields,
-                                    validated_against_schema_version = validated_against_schema_version
-                                )
-                                self.evidence_strings.append(evidence)
-                            except:
-                                self.logger.warning('Evidence generation failed for row: {}'.format(c))
-                                raise
+                                try:
+                                    evidence = self.evidence_builder.Opentargets(
+                                        type = type,
+                                        access_level = access_level,
+                                        sourceID = sourceID,
+                                        evidence = evidence,
+                                        target = target,
+                                        disease = disease_info,
+                                        unique_association_fields = unique_association_fields,
+                                        validated_against_schema_version = validated_against_schema_version
+                                    )
+                                    self.evidence_strings.append(evidence)
+                                except:
+                                    self.logger.warning('Evidence generation failed for row: {}'.format(c))
+                                    raise
                     else:
                         self._logger.error("%s\t%s not mapped: please check manually"%(disease_name, disease_mim))
 

--- a/modules/Gene2Phenotype.py
+++ b/modules/Gene2Phenotype.py
@@ -3,11 +3,6 @@ from common.HGNCParser import GeneParser
 from common.RareDiseasesUtils import RareDiseaseMapper
 
 import python_jsonschema_objects as pjo
-#import opentargets.model.core as opentargets
-#import opentargets.model.bioentity as bioentity
-#import opentargets.model.evidence.core as evidence_core
-#import opentargets.model.evidence.linkout as evidence_linkout
-#import opentargets.model.evidence.association_score as association_score
 
 import sys
 import logging

--- a/modules/Gene2Phenotype.py
+++ b/modules/Gene2Phenotype.py
@@ -11,10 +11,10 @@ import gzip
 import requests
 import datetime
 
-__copyright__  = "Copyright 2014-2019, Open Targets"
-__credits__    = ["Gautier Koscielny", "ChuangKee Ong", "Michaela Spitzer"]
+__copyright__  = "Copyright 2014-2020, Open Targets"
+__credits__    = ["Gautier Koscielny", "ChuangKee Ong", "Michaela Spitzer", "Asier Gonzalez" ]
 __license__    = "Apache 2.0"
-__version__    = "1.2.8"
+__version__    = "1.3.0"
 __maintainer__ = "Open Targets Data Team"
 __email__      = ["data@opentargets.org"]
 __status__     = "Production"

--- a/settings.py
+++ b/settings.py
@@ -40,6 +40,7 @@ class Config:
 
     # schema version
     VALIDATED_AGAINST_SCHEMA_VERSION = '1.2.8'
+    OT_JSON_SCHEMA = "https://raw.githubusercontent.com/opentargets/json_schema/Draft-4_compatible/opentargets.json"
 
     # Ontologies
     EFO_URL = 'https://github.com/EBISPOT/efo/raw/v2018-01-15/efo.obo'
@@ -72,7 +73,7 @@ class Config:
 
     # Gene2Phenotype
     #G2P_FILENAME = 'DDG2P.csv.gz'
-    G2P_FILENAME = file_or_resource('DDG2P_19_8_2019.csv.gz')
+    G2P_FILENAME = file_or_resource('DDG2P_2_4_2020.csv.gz')
     G2P_EVIDENCE_FILENAME = 'gene2phenotype-19-08-2019.json'
 
     # Genomics England


### PR DESCRIPTION
Two main changes:

- Gene2Phenotype parser uses `python_jsonschema_objects` library to build the evidence
- The function `get_omim_to_efo_mappings` in `RareDiseaseUtils.py` has been updated to match the new format of the mapping file, which now has two fewer columns.