### PR TITLE
[il-GEL] Updated script

### DIFF
--- a/modules/GenomicsEnglandPanelApp.py
+++ b/modules/GenomicsEnglandPanelApp.py
@@ -320,6 +320,8 @@ class PanelApp_evidence_generator():
                     'resource_score' : resource_score,
                     'urls' : urls,
                     'confidence' : self.evidence_classification,
+                    'panel_id': self.panel_id,
+                    'panel_version': self.panel_version,
                     'allelic_requirement' : self.mode_of_inheritance
                     }
 
@@ -340,7 +342,6 @@ class PanelApp_evidence_generator():
                         'disease_iri': self.mapped_id,
                         'target_id': self.ensembl_iri,
                         'panel_id': self.panel_id,
-                        'panel_name': self.panel_name,
                         'panel_version': self.panel_version,
                         'original_disease_name': self.source_disease,
                     }

--- a/modules/GenomicsEnglandPanelApp.py
+++ b/modules/GenomicsEnglandPanelApp.py
@@ -108,7 +108,7 @@ class PanelApp_evidence_generator():
     @staticmethod
     def clean_dataframe(dataframe):
         '''
-        Cleaning of the initial .tsv or .csv file
+        Cleaning of the initial .tsv file
         '''
 
         # NaNs and "No OMIM phenotype" in "Phenotypes" column --> Assignment of Pannel Name
@@ -131,6 +131,8 @@ class PanelApp_evidence_generator():
         dataframe["Phenotypes"] = dataframe["Phenotypes"].str.replace("-", " ", regex=False)
         dataframe["Phenotypes"] = dataframe["Phenotypes"].str.replace("[^0-9a-zA-Z *]", "", regex=True)
         dataframe["Phenotypes"] = dataframe["Phenotypes"].apply(lambda X: X.strip())
+
+        dataframe.reset_index(inplace=True)
 
         return dataframe
 
@@ -247,7 +249,7 @@ class PanelApp_evidence_generator():
         self.gene_symbol = row["Symbol"]
         self.mapped_disease = row["OnToma Label"]
         self.mapped_id = row["OnToma Term"]
-        self.source_array = row["phenotype_list"].split(";")
+        self.phenotypes_array = row["phenotype_list"].split(";")
         self.source_name = row["Phenotypes"]
         self.mode_of_inheritance = row["Mode of inheritance"]
         self.evidence_classification = row["List"]
@@ -321,8 +323,9 @@ class PanelApp_evidence_generator():
                     'resource_score' : resource_score,
                     'urls' : urls,
                     'confidence' : self.evidence_classification,
-                    'panel_id': self.panel_id,
-                    'panel_version': self.panel_version,
+                    'study_overview': self.panel_name,
+                    'study_id': self.panel_id,
+                    'study_version': self.panel_version,
                     'allelic_requirement' : self.mode_of_inheritance,
                     'phenotypes_array' : self.phenotypes_array
                     }
@@ -343,10 +346,10 @@ class PanelApp_evidence_generator():
         unique_association_field = {
                         'disease_iri': self.mapped_id,
                         'target_id': self.ensembl_iri,
-                        'panel_id': self.panel_id,
-                        'panel_name': self.panel_name,
-                        'panel_version': self.panel_version,
-                        'original_disease_name': self.source_disease,
+                        'study_overview': self.panel_name,
+                        'study_id': self.panel_id,
+                        'study_version': self.panel_version,
+                        'original_disease_name': self.source_name,
                     }
 
         try:

--- a/modules/GenomicsEnglandPanelApp.py
+++ b/modules/GenomicsEnglandPanelApp.py
@@ -319,7 +319,8 @@ class PanelApp_evidence_generator():
                     'provenance_type' : provenance_type,
                     'resource_score' : resource_score,
                     'urls' : urls,
-                    'confidence' : self.evidence_classification
+                    'confidence' : self.evidence_classification,
+                    'allelic_requirement' : self.mode_of_inheritance
                     }
 
         target_field = {

--- a/modules/GenomicsEnglandPanelApp.py
+++ b/modules/GenomicsEnglandPanelApp.py
@@ -247,7 +247,8 @@ class PanelApp_evidence_generator():
         self.gene_symbol = row["Symbol"]
         self.mapped_disease = row["OnToma Label"]
         self.mapped_id = row["OnToma Term"]
-        self.source_disease = row["phenotype_list"]
+        self.source_array = row["phenotype_list"].split(";")
+        self.source_name = row["Phenotypes"]
         self.mode_of_inheritance = row["Mode of inheritance"]
         self.evidence_classification = row["List"]
         self.sources = row["Sources"]
@@ -322,7 +323,8 @@ class PanelApp_evidence_generator():
                     'confidence' : self.evidence_classification,
                     'panel_id': self.panel_id,
                     'panel_version': self.panel_version,
-                    'allelic_requirement' : self.mode_of_inheritance
+                    'allelic_requirement' : self.mode_of_inheritance,
+                    'phenotypes_array' : self.phenotypes_array
                     }
 
         target_field = {
@@ -335,13 +337,14 @@ class PanelApp_evidence_generator():
         disease_field = {
                         'id': self.mapped_id,
                         'name' : self.mapped_disease,
-                        'source_name': self.source_disease
+                        'source_name': self.source_name
                     }
         
         unique_association_field = {
                         'disease_iri': self.mapped_id,
                         'target_id': self.ensembl_iri,
                         'panel_id': self.panel_id,
+                        'panel_name': self.panel_name,
                         'panel_version': self.panel_version,
                         'original_disease_name': self.source_disease,
                     }


### PR DESCRIPTION
As discussed on Friday 13th, four changes have been made to the current Panel App parser:

1. `evidence.allelic_requirement` has been added;
2. `panel_id, panel_name, panel_version` have been changed to `study_id, study_name, study_version`. In addition, these fields are not only in `unique_association_fields` but also can be found under `evidence`;
3. `disease.source_name` now shows the phenotype of the evidence, not the original string;
4. `evidence.phenotypes_array` has been added, as an array listing all the phenotypes present in the source string

[This is an example](https://github.com/opentargets/evidence_datasource_parsers/files/5546478/test-results.json.gz) of a newly generated string.

Thinking about possible incompatibilities with FE, please see if we should limit the `evidence.allelic_requirement` string.

A small set of strings have been generated and validated. The new pipeline is currently running.