### PR TITLE
Ag phenodigm file extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,8 @@ python3 modules/MouseModels.py
 # Upload the evidence file to Google Cloud Storage
 python3 modules/MouseModels.py -w
 ```
-**NOTE:** Remember to stop the machine once you are done as it costs money to have it on! 
+**CAVEAT:** The last step (`-w`) tries to upload a file with the current date in the name, which may not work if the parser was run on another day, which would be the date on the filename.
+**REMINDER:** Remember to stop the machine once you are done as it costs money to have it on! 
 
 ### Open Targets Genetics Portal
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ python3 modules/MouseModels.py
 python3 modules/MouseModels.py -w
 ```
 **CAVEAT:** The last step (`-w`) tries to upload a file with the current date in the name, which may not work if the parser was run on another day, which would be the date on the filename.
+
 **REMINDER:** Remember to stop the machine once you are done as it costs money to have it on! 
 
 ### Open Targets Genetics Portal

--- a/modules/MouseModels.py
+++ b/modules/MouseModels.py
@@ -27,12 +27,12 @@ import opentargets.model.evidence.association_score as association_score
 logging.basicConfig(filename='phenodigm.log', filemode='w', level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-__copyright__ = "Copyright 2014-2019, Open Targets"
-__credits__ = ["Gautier Koscielny", "Damian Smedley"]
+__copyright__ = "Copyright 2014-2021, Open Targets"
+__credits__ = ["Gautier Koscielny", "Damian Smedley", "Asier Gonzalez"]
 __license__ = "Apache 2.0"
 __version__ = Config.VALIDATED_AGAINST_SCHEMA_VERSION
-__maintainer__ = "Gautier Koscielny"
-__email__ = "gautierk@opentargets.org"
+__maintainer__ = "Open Targets Data Team"
+__email__ = ["data@opentargets.org"]
 __status__ = "Production"
 
 class Phenodigm(RareDiseaseMapper, GCSBucketManager):

--- a/modules/MouseModels.py
+++ b/modules/MouseModels.py
@@ -746,6 +746,7 @@ class Phenodigm(RareDiseaseMapper, GCSBucketManager):
         logger.info("Exported %i evidence" % (countExported))
 
     def write_to_cloud(self, filename):
+        # TODO: Take into account that filename at this step may not match the one saved because time stamp is automatic
 
         # The name of the blob. This corresponds to the unique path of the object in the bucket.
         # Uploading the file to otar000-evidence_input/PhenoDigm/json

--- a/settings.py
+++ b/settings.py
@@ -101,7 +101,7 @@ class Config:
     MOUSEMODELS_PHENODIGM_SOLR = 'http://www.ebi.ac.uk/mi/impc'
     # write to the cloud direcly
     MOUSEMODELS_CACHE_DIRECTORY = 'PhenoDigm/phenodigmcache'
-    MOUSEMODELS_EVIDENCE_FILENAME = f"phenodigm-{datetime.today().strftime('%Y-%m-%d')}.json"
+    MOUSEMODELS_EVIDENCE_FILENAME = f"phenodigm-{datetime.today().strftime('%Y-%m-%d')}.json.gz"
 
     # Configuration for genetics portal evidences:
     ACTIVITY_URL = 'http://identifiers.org/cttv.activity'


### PR DESCRIPTION
Two changes related to PhenoDigm:

- The output filename was lacking the gz extension
- Note added to the README to explain that the last (`-w`) may fail if the main step and the upload are run on different days because the date is automatically added to the file name.