### PR TITLE
Ag clingen new schema 1278

### DIFF
--- a/modules/ClinGen.py
+++ b/modules/ClinGen.py
@@ -8,15 +8,6 @@ import pandas as pd
 import requests
 import argparse
 
-ClinGen_classification2score = {
-    "Definitive": 1,
-    "Strong": 1,
-    "Moderate": 0.5,
-    "Limited": 0.01,
-    "Disputed": 0.01,
-    "Refuted": 0.01,
-    "No Reported Evidence": 0.01,
-}
 
 class ClinGen():
     def __init__(self):
@@ -131,17 +122,6 @@ class ClinGen():
                 # *** Target fields ***
                 target_from_source_id = gene_symbol
 
-                # *** Evidence info ***
-                # Score based on disease confidence/ classification
-                if classification in ClinGen_classification2score:
-                    score = ClinGen_classification2score[classification]
-                else:
-                    self.logger.error('{} is not a recognised ClinGen classification, assigning an score of 0'.format(classification))
-                    score = 0
-                resource_score = {
-                    'type': "probability",
-                    'value': score
-                }
 
                 # Linkout
                 linkout = [

--- a/modules/ClinGen.py
+++ b/modules/ClinGen.py
@@ -128,14 +128,8 @@ class ClinGen():
                 # *** General properties ***
                 sourceID = "clingen"
 
-                # *** Target info ***
-                target = {
-                    'id' : ensembl_iri,
-                    'activity' : "http://identifiers.org/cttv.activity/unknown",
-                    'target_type' : "http://identifiers.org/cttv.target/gene_evidence",
-                    'target_name' : gene_symbol
-                }
-                # http://www.ontobee.org/ontology/ECO?iri=http://purl.obolibrary.org/obo/ECO_0000204 -- An evidence type that is based on an assertion by the author of a paper, which is read by a curator.
+                # *** Target fields ***
+                target_from_source_id = gene_symbol
 
                 # *** Evidence info ***
                 # Score based on disease confidence/ classification

--- a/modules/ClinGen.py
+++ b/modules/ClinGen.py
@@ -125,23 +125,8 @@ class ClinGen():
 
                 type = "genetic_literature"
 
-                provenance_type = {
-                    'database' : {
-                        'id' : "ClinGen - Gene Validity Curations",
-                        'version' : file_created_date,
-                        'dbxref' : {
-                            'url': "https://search.clinicalgenome.org/kb/gene-validity",
-                            'id' : "ClinGen - Gene Validity Curations",
-                            'version' : file_created_date
-
-                        }
-                    }
-                }
-
                 # *** General properties ***
-                access_level = "public"
                 sourceID = "clingen"
-                validated_against_schema_version = self.schema_version
 
                 # *** Target info ***
                 target = {

--- a/modules/ClinGen.py
+++ b/modules/ClinGen.py
@@ -51,12 +51,6 @@ class ClinGen():
     def generate_evidence_strings(self, filename):
 
         # When reading csv file first extract date from second row and the skip header lines that don't contain column names
-        # CLINGEN GENE VALIDITY CURATIONS
-        # FILE CREATED: 2020-07-16
-        # WEBPAGE: https://search.clinicalgenome.org/kb/gene-validity
-        # +++++++++++,++++++++++++++,+++++++++++++,++++++++++++++++++,+++++++++,+++++++++,++++++++++++++,+++++++++++++,+++++++++++++++++++
-        # GENE SYMBOL,GENE ID (HGNC),DISEASE LABEL,DISEASE ID (MONDO),MOI,SOP,CLASSIFICATION,ONLINE REPORT,CLASSIFICATION DATE
-        # +++++++++++,++++++++++++++,+++++++++++++,++++++++++++++++++,+++++++++,+++++++++,++++++++++++++,+++++++++++++,+++++++++++++++++++
 
         # Read first two rows of file to extract date
         with open(filename) as f:

--- a/modules/ClinGen.py
+++ b/modules/ClinGen.py
@@ -138,9 +138,6 @@ def main():
     parser.add_argument('-o', '--output_file',
                         help='Name of evidence file',
                         type=str, required=True)
-    parser.add_argument('-s', '--schema_version',
-                        help='JSON schema version to use, e.g. 1.6.8. It must be branch or a tag available in https://github.com/opentargets/json_schema',
-                        type=str, required=True)
     parser.add_argument('-u', '--unmapped_diseases_file',
                         help='If specified, the diseases not mapped to EFO will be stored in this file',
                         type=str, default=False)
@@ -149,10 +146,9 @@ def main():
     # Get parameters
     infile = args.input_file
     outfile = args.output_file
-    schema_version = args.schema_version
     unmapped_diseases_file = args.unmapped_diseases_file
 
-    clingen = ClinGen(schema_version=schema_version)
+    clingen = ClinGen()
     clingen.process_gene_validity_curations(infile, outfile, unmapped_diseases_file)
 
 if __name__ == "__main__":

--- a/modules/ClinGen.py
+++ b/modules/ClinGen.py
@@ -1,5 +1,4 @@
 from settings import Config
-from common.HGNCParser import GeneParser
 import ontoma
 
 import python_jsonschema_objects as pjo
@@ -74,10 +73,6 @@ class ClinGen():
 
     def process_gene_validity_curations(self, in_filename, out_filename, unmapped_diseases_filename):
 
-        gene_parser = GeneParser()
-        gene_parser._get_hgnc_data_from_json()
-        self.genes = gene_parser.genes
-
         self.generate_evidence_strings(in_filename)
 
         # Save results to file
@@ -118,130 +113,125 @@ class ClinGen():
 
             gene_symbol.rstrip()
 
-            if gene_symbol in self.genes:
-                # Map gene symbol to ensembl
-                target = self.genes[gene_symbol]
-                ensembl_iri = "http://identifiers.org/ensembl/" + target
-
-                # Check that disease id exists in EFO or find equivalent term
-                # If id is not found in EFO OBO file the function returns None
-                if self.ontoma.get_efo_label(disease_id):
-                    disease_label = self.ontoma.get_efo_label(disease_id)
-                    # Create list of single disease to mimic what is returned by next step
-                    efo_mappings = [{'id': disease_id, 'name': disease_label}]
-                elif self.ontoma.get_efo_from_xref(disease_id):
-                    efo_mappings = self.ontoma.get_efo_from_xref(disease_id)
-                    self._logger.info("{} mapped to {} EFO ids based on xrefs.".format(disease_id, len(efo_mappings)))
-                else:
-                    # Search disease label using OnToma and accept perfect matches
-                    ontoma_mapping = self.ontoma.find_term(disease_name, verbose=True)
-                    if ontoma_mapping:
-                        if ontoma_mapping['action'] is None:
-                            efo_mappings = [{'id': ontoma_mapping['term'], 'name': ontoma_mapping['label']}]
-                        else:
-                            # OnToma fuzzy match ignored
-                            self._logger.info("Fuzzy match from OnToma ignored. Request EFO team to import {} - {}".format(disease_name, disease_id))
-                            # Record the unmapped disease
-                            self.unmapped_diseases.add((disease_id, disease_name))
-                            continue
+            # Check that disease id exists in EFO or find equivalent term
+            # If id is not found in EFO OBO file the function returns None
+            if self.ontoma.get_efo_label(disease_id):
+                disease_label = self.ontoma.get_efo_label(disease_id)
+                # Create list of single disease to mimic what is returned by next step
+                efo_mappings = [{'id': disease_id, 'name': disease_label}]
+            elif self.ontoma.get_efo_from_xref(disease_id):
+                efo_mappings = self.ontoma.get_efo_from_xref(disease_id)
+                self._logger.info("{} mapped to {} EFO ids based on xrefs.".format(disease_id, len(efo_mappings)))
+            else:
+                # Search disease label using OnToma and accept perfect matches
+                ontoma_mapping = self.ontoma.find_term(disease_name, verbose=True)
+                if ontoma_mapping:
+                    if ontoma_mapping['action'] is None:
+                        efo_mappings = [{'id': ontoma_mapping['term'], 'name': ontoma_mapping['label']}]
                     else:
-                        # MONDO id could not be found in EFO. Log it and continue
-                        self._logger.info("{} - {} could not be mapped to any EFO id. Skipping it, it should be checked with the EFO team".format(disease_name, disease_id))
+                        # OnToma fuzzy match ignored
+                        self._logger.info("Fuzzy match from OnToma ignored. Request EFO team to import {} - {}".format(disease_name, disease_id))
                         # Record the unmapped disease
                         self.unmapped_diseases.add((disease_id, disease_name))
                         continue
+                else:
+                    # MONDO id could not be found in EFO. Log it and continue
+                    self._logger.info("{} - {} could not be mapped to any EFO id. Skipping it, it should be checked with the EFO team".format(disease_name, disease_id))
+                    # Record the unmapped disease
+                    self.unmapped_diseases.add((disease_id, disease_name))
+                    continue
 
-                for efo_mapping in efo_mappings:
+            for efo_mapping in efo_mappings:
 
-                    # *** Disease info ***
-                    disease_info = {
-                        'id': ontoma.interface.make_uri(efo_mapping['id']),
-                        'name' : efo_mapping['name'],
-                        'source_name': disease_name
-                    }
+                # *** Disease info ***
+                disease_info = {
+                    'id': ontoma.interface.make_uri(efo_mapping['id']),
+                    'name' : efo_mapping['name'],
+                    'source_name': disease_name
+                }
 
-                    type = "genetic_literature"
+                type = "genetic_literature"
 
-                    provenance_type = {
-                        'database' : {
+                provenance_type = {
+                    'database' : {
+                        'id' : "ClinGen - Gene Validity Curations",
+                        'version' : file_created_date,
+                        'dbxref' : {
+                            'url': "https://search.clinicalgenome.org/kb/gene-validity",
                             'id' : "ClinGen - Gene Validity Curations",
-                            'version' : file_created_date,
-                            'dbxref' : {
-                                'url': "https://search.clinicalgenome.org/kb/gene-validity",
-                                'id' : "ClinGen - Gene Validity Curations",
-                                'version' : file_created_date
+                            'version' : file_created_date
 
-                            }
                         }
                     }
+                }
 
-                    # *** General properties ***
-                    access_level = "public"
-                    sourceID = "clingen"
-                    validated_against_schema_version = self.schema_version
+                # *** General properties ***
+                access_level = "public"
+                sourceID = "clingen"
+                validated_against_schema_version = self.schema_version
 
-                    # *** Target info ***
-                    target = {
-                        'id' : ensembl_iri,
-                        'activity' : "http://identifiers.org/cttv.activity/unknown",
-                        'target_type' : "http://identifiers.org/cttv.target/gene_evidence",
-                        'target_name' : gene_symbol
+                # *** Target info ***
+                target = {
+                    'id' : ensembl_iri,
+                    'activity' : "http://identifiers.org/cttv.activity/unknown",
+                    'target_type' : "http://identifiers.org/cttv.target/gene_evidence",
+                    'target_name' : gene_symbol
+                }
+                # http://www.ontobee.org/ontology/ECO?iri=http://purl.obolibrary.org/obo/ECO_0000204 -- An evidence type that is based on an assertion by the author of a paper, which is read by a curator.
+
+                # *** Evidence info ***
+                # Score based on disease confidence/ classification
+                if classification in ClinGen_classification2score:
+                    score = ClinGen_classification2score[classification]
+                else:
+                    self.logger.error('{} is not a recognised ClinGen classification, assigning an score of 0'.format(classification))
+                    score = 0
+                resource_score = {
+                    'type': "probability",
+                    'value': score
+                }
+
+                # Linkout
+                linkout = [
+                    {
+                        'url' : report_url,
+                        'nice_name' : 'Gene Validity Curations: {} - {} report'.format(gene_symbol, disease_name)
                     }
-                    # http://www.ontobee.org/ontology/ECO?iri=http://purl.obolibrary.org/obo/ECO_0000204 -- An evidence type that is based on an assertion by the author of a paper, which is read by a curator.
+                ]
 
-                    # *** Evidence info ***
-                    # Score based on disease confidence/ classification
-                    if classification in ClinGen_classification2score:
-                        score = ClinGen_classification2score[classification]
-                    else:
-                        self.logger.error('{} is not a recognised ClinGen classification, assigning an score of 0'.format(classification))
-                        score = 0
-                    resource_score = {
-                        'type': "probability",
-                        'value': score
-                    }
-
-                    # Linkout
-                    linkout = [
-                        {
-                            'url' : report_url,
-                            'nice_name' : 'Gene Validity Curations: {} - {} report'.format(gene_symbol, disease_name)
-                        }
-                    ]
-
-                    evidence = {
-                        'is_associated' : True,
-                        'confidence' : classification,
-                        'allelic_requirement' : mode_of_inheritancr,
-                        'evidence_codes' : ["http://purl.obolibrary.org/obo/ECO_0000204"],
-                        'provenance_type' : provenance_type,
-                        'date_asserted' : date,
-                        'resource_score' : resource_score,
-                        'urls' : linkout
-                    }
-                    # *** unique_association_fields ***
-                    unique_association_fields = {
-                        'target_id' : ensembl_iri,
-                        'disease_id' : disease_id,
-                        'report_url' : report_url
-                    }
+                evidence = {
+                    'is_associated' : True,
+                    'confidence' : classification,
+                    'allelic_requirement' : mode_of_inheritancr,
+                    'evidence_codes' : ["http://purl.obolibrary.org/obo/ECO_0000204"],
+                    'provenance_type' : provenance_type,
+                    'date_asserted' : date,
+                    'resource_score' : resource_score,
+                    'urls' : linkout
+                }
+                # *** unique_association_fields ***
+                unique_association_fields = {
+                    'target_id' : ensembl_iri,
+                    'disease_id' : disease_id,
+                    'report_url' : report_url
+                }
 
 
-                    try:
-                        evidence = self.evidence_builder.Opentargets(
-                            type = type,
-                            access_level = access_level,
-                            sourceID = sourceID,
-                            evidence = evidence,
-                            target = target,
-                            disease = disease_info,
-                            unique_association_fields = unique_association_fields,
-                            validated_against_schema_version = validated_against_schema_version
-                        )
-                        self.evidence_strings.append(evidence)
-                    except:
-                        self._logger.warning('Evidence generation failed for row: {}'.format(index))
-                        raise
+                try:
+                    evidence = self.evidence_builder.Opentargets(
+                        type = type,
+                        access_level = access_level,
+                        sourceID = sourceID,
+                        evidence = evidence,
+                        target = target,
+                        disease = disease_info,
+                        unique_association_fields = unique_association_fields,
+                        validated_against_schema_version = validated_against_schema_version
+                    )
+                    self.evidence_strings.append(evidence)
+                except:
+                    self._logger.warning('Evidence generation failed for row: {}'.format(index))
+                    raise
 
     def write_evidence_strings(self, filename):
         self._logger.info("Writing ClinGen evidence strings to %s", filename)

--- a/modules/ClinGen.py
+++ b/modules/ClinGen.py
@@ -60,7 +60,7 @@ class ClinGen():
             disease_id = row["DISEASE ID (MONDO)"]
             mode_of_inheritance = row["MOI"]
             classification = row["CLASSIFICATION"]
-            date = row["CLASSIFICATION DATE"]
+            expert_panel_name = row["GCEP"]
             report_url = row["ONLINE REPORT"]
 
             gene_symbol.rstrip()
@@ -112,7 +112,7 @@ class ClinGen():
                     'diseaseFromSourceMappedId': efo_mapping['id'],
                     'allelicRequirements': mode_of_inheritance,
                     'confidence': classification,
-                    'studyId': '',
+                    'studyId': expert_panel_name,
                     'clinicalUrls': linkout
                 }
 

--- a/modules/ClinGen.py
+++ b/modules/ClinGen.py
@@ -28,7 +28,7 @@ ClinGen_classification2score = {
 
 class ClinGen():
     def __init__(self, schema_version=Config.VALIDATED_AGAINST_SCHEMA_VERSION):
-        self.genes = None
+
         self.evidence_strings = list()
         self.unmapped_diseases = set()
 

--- a/modules/ClinGen.py
+++ b/modules/ClinGen.py
@@ -118,12 +118,10 @@ class ClinGen():
 
             for efo_mapping in efo_mappings:
 
-                # *** Disease info ***
-                disease_info = {
-                    'id': ontoma.interface.make_uri(efo_mapping['id']),
-                    'name' : efo_mapping['name'],
-                    'source_name': disease_name
-                }
+                # *** Disease fields ***
+                disease_from_source = disease_name
+                disease_from_source_id = disease_id
+                disease_from_source_mapped_id = efo_mapping['id']
 
                 type = "genetic_literature"
 

--- a/modules/ClinGen.py
+++ b/modules/ClinGen.py
@@ -123,7 +123,7 @@ class ClinGen():
                 target_from_source_id = gene_symbol
 
 
-                # Linkout
+                # FIXME: Store report URL in field designed for ChEMBL clinical trials URLs
                 linkout = [
                     {
                         'url' : report_url,

--- a/modules/ClinGen.py
+++ b/modules/ClinGen.py
@@ -141,12 +141,6 @@ class ClinGen():
                     'resource_score' : resource_score,
                     'urls' : linkout
                 }
-                # *** unique_association_fields ***
-                unique_association_fields = {
-                    'target_id' : ensembl_iri,
-                    'disease_id' : disease_id,
-                    'report_url' : report_url
-                }
 
 
                 try:

--- a/modules/ClinGen.py
+++ b/modules/ClinGen.py
@@ -50,15 +50,7 @@ class ClinGen():
 
     def generate_evidence_strings(self, filename):
 
-        # When reading csv file first extract date from second row and the skip header lines that don't contain column names
-
-        # Read first two rows of file to extract date
-        with open(filename) as f:
-            f.readline() # Don't do anything with first row
-            second_row = f.readline()
-            file_created_date = second_row.split(": ")[1].strip() # Extract date and clean it
-
-
+        # When reading csv file skip header lines that don't contain column names
         gene_validity_curation_df = pd.read_csv(filename, skiprows= [0,1,2,3,5], quotechar='"')
         for index, row in gene_validity_curation_df.iterrows():
             print("{} - {}".format(row["GENE SYMBOL"], row["DISEASE LABEL"]))

--- a/modules/ClinGen.py
+++ b/modules/ClinGen.py
@@ -19,7 +19,7 @@ ClinGen_classification2score = {
 }
 
 class ClinGen():
-    def __init__(self, schema_version=Config.VALIDATED_AGAINST_SCHEMA_VERSION):
+    def __init__(self):
 
         self.evidence_strings = list()
         self.unmapped_diseases = set()
@@ -41,23 +41,6 @@ class ClinGen():
 
         # Add ch to handler
         self._logger.addHandler(ch)
-
-        # Build JSON schema url from version
-        self.schema_version = schema_version
-        schema_url = "https://raw.githubusercontent.com/opentargets/json_schema/" + self.schema_version + "/draft4_schemas/opentargets.json"
-        self._logger.info('Loading JSON schema at {}'.format(schema_url))
-
-        # Initialize json builder based on the schema:
-        try:
-            r = requests.get(schema_url)
-            r.raise_for_status()
-            json_schema = r.json()
-            self.builder = pjo.ObjectBuilder(json_schema)
-            self.evidence_builder = self.builder.build_classes()
-            self.schema_version = schema_version
-        except requests.exceptions.HTTPError as e:
-            self._logger.error('Invalid JSON schema version')
-            raise e
 
         # Create OnToma object
         self.ontoma = ontoma.interface.OnToma()

--- a/modules/ClinGen.py
+++ b/modules/ClinGen.py
@@ -72,7 +72,7 @@ class ClinGen():
             gene_symbol = row["GENE SYMBOL"]
             disease_name = row["DISEASE LABEL"]
             disease_id = row["DISEASE ID (MONDO)"]
-            mode_of_inheritancr = row["MOI"]
+            mode_of_inheritance = row["MOI"]
             classification = row["CLASSIFICATION"]
             date = row["CLASSIFICATION DATE"]
             report_url = row["ONLINE REPORT"]
@@ -109,20 +109,6 @@ class ClinGen():
 
             for efo_mapping in efo_mappings:
 
-                # *** Disease fields ***
-                disease_from_source = disease_name
-                disease_from_source_id = disease_id
-                disease_from_source_mapped_id = efo_mapping['id']
-
-                type = "genetic_literature"
-
-                # *** General properties ***
-                sourceID = "clingen"
-
-                # *** Target fields ***
-                target_from_source_id = gene_symbol
-
-
                 # FIXME: Store report URL in field designed for ChEMBL clinical trials URLs
                 linkout = [
                     {
@@ -132,32 +118,19 @@ class ClinGen():
                 ]
 
                 evidence = {
-                    'is_associated' : True,
-                    'confidence' : classification,
-                    'allelic_requirement' : mode_of_inheritancr,
-                    'evidence_codes' : ["http://purl.obolibrary.org/obo/ECO_0000204"],
-                    'provenance_type' : provenance_type,
-                    'date_asserted' : date,
-                    'resource_score' : resource_score,
-                    'urls' : linkout
+                    'datasourceId' : 'clingen',
+                    'datatypeId' : 'genetic_literature',
+                    'targetFromSourceId' : gene_symbol,
+                    'diseaseFromSource': disease_name,
+                    'diseaseFromSourceId': disease_id,
+                    'diseaseFromSourceMappedId': efo_mapping['id'],
+                    'allelicRequirements': mode_of_inheritance,
+                    'confidence': classification,
+                    'studyId': '',
+                    'clinicalUrls': linkout
                 }
 
-
-                try:
-                    evidence = self.evidence_builder.Opentargets(
-                        type = type,
-                        access_level = access_level,
-                        sourceID = sourceID,
-                        evidence = evidence,
-                        target = target,
-                        disease = disease_info,
-                        unique_association_fields = unique_association_fields,
-                        validated_against_schema_version = validated_against_schema_version
-                    )
-                    self.evidence_strings.append(evidence)
-                except:
-                    self._logger.warning('Evidence generation failed for row: {}'.format(index))
-                    raise
+                self.evidence_strings.append(evidence)
 
     def write_evidence_strings(self, filename):
         self._logger.info("Writing ClinGen evidence strings to %s", filename)

--- a/modules/ClinGen.py
+++ b/modules/ClinGen.py
@@ -106,8 +106,8 @@ class ClinGen():
                     'targetFromSourceId' : gene_symbol,
                     'diseaseFromSource': disease_name,
                     'diseaseFromSourceId': disease_id,
-                    'diseaseFromSourceMappedId': efo_mapping['id'],
-                    'allelicRequirements': mode_of_inheritance,
+                    'diseaseFromSourceMappedId': ontoma.interface.make_uri(efo_mapping['id']).split("/")[-1],
+                    'allelicRequirements': [mode_of_inheritance],
                     'confidence': classification,
                     'studyId': expert_panel_name,
                     'clinicalUrls': linkout

--- a/modules/ClinGen.py
+++ b/modules/ClinGen.py
@@ -8,14 +8,6 @@ import pandas as pd
 import requests
 import argparse
 
-__copyright__  = "Copyright 2014-2020, Open Targets"
-__credits__    = ["Asier Gonzalez" ]
-__license__    = "Apache 2.0"
-__version__    = "0.0.1"
-__maintainer__ = "Open Targets Data Team"
-__email__      = ["data@opentargets.org"]
-__status__     = "Prototype"
-
 ClinGen_classification2score = {
     "Definitive": 1,
     "Strong": 1,

--- a/modules/ClinGen.py
+++ b/modules/ClinGen.py
@@ -92,11 +92,9 @@ class ClinGen():
 
             for efo_mapping in efo_mappings:
 
-                # FIXME: Store report URL in field designed for ChEMBL clinical trials URLs
                 linkout = [
                     {
-                        'url' : report_url,
-                        'nice_name' : 'Gene Validity Curations: {} - {} report'.format(gene_symbol, disease_name)
+                        'url' : report_url
                     }
                 ]
 
@@ -110,7 +108,7 @@ class ClinGen():
                     'allelicRequirements': [mode_of_inheritance],
                     'confidence': classification,
                     'studyId': expert_panel_name,
-                    'clinicalUrls': linkout
+                    'urls': linkout
                 }
 
                 self.evidence_strings.append(evidence)

--- a/modules/ClinGen.py
+++ b/modules/ClinGen.py
@@ -3,6 +3,7 @@ import ontoma
 import logging
 import pandas as pd
 import argparse
+import json
 
 
 class ClinGen():
@@ -118,7 +119,8 @@ class ClinGen():
         self._logger.info("Writing ClinGen evidence strings to %s", filename)
         with open(filename, 'w') as tp_file:
             for evidence_string in self.evidence_strings:
-                tp_file.write(evidence_string.serialize() + "\n")
+                json.dump(evidence_string, tp_file)
+                tp_file.write("\n")
 
     def write_unmapped_diseases(self, filename):
         self._logger.info("Writing ClinGen diseases not mapped to EFO to %s", filename)

--- a/modules/ClinGen.py
+++ b/modules/ClinGen.py
@@ -1,11 +1,7 @@
-from settings import Config
 import ontoma
-
-import python_jsonschema_objects as pjo
 
 import logging
 import pandas as pd
-import requests
 import argparse
 
 


### PR DESCRIPTION
Revamp of the ClinGen parser to align evidence strings with new schema. This is the summary of the changes made:

- JSON schema is **NOT** loaded
- Gene symbols are **NOT** mapped to Ensembl
- Evidence strings are stored as dictionaries and serialised as JSON
- The name of Gene Curation Expert Panel (`GCEP` column) is stored in the `studyId` field aking to what is done in Gene2Phenotype or Genomics England PanelApp evidence strings.
- The report url needed to link to ClinGen's website is stored in `urls`.
- Unique association fields have been removed because they are now controlled by the ETL pipeline.
- The script metadata has been removed from the code
- The scoring based on the classification/confidence has been removed.
