### PR TITLE
Ag g2p new schema 1279

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,6 @@ The mapping of the diseases, i.e. the "disease name" column, is done on the fly 
 - If OnToma returns a fuzzy match it is ignore and MONDO is searched for exact matches.
 - When no exact matches are found the disease is considered unmapped and it's saved to a file (see the `-u`/ `--unmapped_disease_file` option below).
 
-The parser requires two parameters to run:
-- `-s`, `--schema_version`: JSON schema version to use, e.g. 1.6.8. It must be branch or a tag available in https://github.com/opentargets/json_schema.
-- `-v`, `--g2p_version`: Version of the Gene2Phenotype data used. If not available please use the date in which the data was downloaded in YYYY-MM-DD format.
 
 There are also a number of optional parameters to specify the name of the input and out files:
 - `-d`, `--dd_panel`: Name of Developmental Disorders (DD) panel file. It uses the value of G2P_DD_FILENAME in setting.py if not specified.
@@ -114,7 +111,7 @@ Note that when using the default file names, the input files have to exist in th
 
 To use the parser configure the python environment and run it as follows:
 ```bash
-(venv)$ python3 modules/Gene2Phenotype.py -s 1.7.1 -v 2020-08-19 -d DDG2P_19_8_2020.csv.gz -e EyeG2P_19_8_2020.csv.gz -k SkinG2P_19_8_2020.csv.gz -c CancerG2P_19_8_2020.csv.gz -o gene2phenotype-19-08-2020.json -u gene2phenotype-19-08-2020_unmapped_diseases.txt 
+(venv)$ python3 modules/Gene2Phenotype.py -d DDG2P_19_8_2020.csv.gz -e EyeG2P_19_8_2020.csv.gz -k SkinG2P_19_8_2020.csv.gz -c CancerG2P_19_8_2020.csv.gz -o gene2phenotype-19-08-2020.json -u gene2phenotype-19-08-2020_unmapped_diseases.txt 
 ```
 
 ### Genomics England Panel App

--- a/modules/Gene2Phenotype.py
+++ b/modules/Gene2Phenotype.py
@@ -271,12 +271,6 @@ class G2P(RareDiseaseMapper):
                             'references' : self.get_pub_array(pmids.split(";"))
                         }
 
-                    # *** Disease info ***
-                    disease_info = {
-                        'id' : disease_mapping['id'],
-                        'name' : disease_mapping['name'],
-                        'source_name' : disease_name
-                    }
                     # *** Evidence info ***
                     # Score based on mutational consequence
                     if confidence in G2P_confidence2score:
@@ -317,8 +311,8 @@ class G2P(RareDiseaseMapper):
                         'datatypeId': 'genetic_literature',
                         'targetFromSourceId': gene_symbol.rstrip(),
                         'diseaseFromSource': disease_name,
-                        'diseaseFromSourceId': disease_id,
-                        'diseaseFromSourceMappedId': ontoma.interface.make_uri(efo_mapping['id']).split("/")[-1],
+                        'diseaseFromSourceId': disease_mim,
+                        'diseaseFromSourceMappedId': ontoma.interface.make_uri(disease_mapping['id']).split("/")[-1],
                         'allelicRequirements': [mode_of_inheritance],
                         'confidence': classification,
                         'literature': ,

--- a/modules/Gene2Phenotype.py
+++ b/modules/Gene2Phenotype.py
@@ -244,7 +244,10 @@ class G2P():
 
                     # Assign SO code based on mutation consequence field
                     if mutation_consequence in G2P_mutationCsq2functionalCsq:
-                        evidence['variantFunctionalConsequenceId'] = G2P_mutationCsq2functionalCsq[mutation_consequence]
+                        if G2P_mutationCsq2functionalCsq[mutation_consequence]:
+                            evidence['variantFunctionalConsequenceId'] = G2P_mutationCsq2functionalCsq[mutation_consequence]
+                        else:
+                            self._logger.error('Ignoring empty mutation consequence'.format(mutation_consequence))
                     else:
                         self._logger.error( '{} is not a recognised G2P mutation consequence, ignoring the value'.format(mutation_consequence))
 

--- a/modules/Gene2Phenotype.py
+++ b/modules/Gene2Phenotype.py
@@ -266,30 +266,11 @@ class G2P(RareDiseaseMapper):
 
                     self._logger.info(f"{gene_symbol}, {target}, '{disease_name}', {disease_mapping['id']}")
 
-                    type = "genetic_literature"
-
-                    provenance_type = {
-                        'database' : {
-                            'id' : "Gene2Phenotype",
-                            'version' : self.g2p_version,
-                            'dbxref' : {
-                                'url': "http://www.ebi.ac.uk/gene2phenotype",
-                                'id' : "Gene2Phenotype",
-                                'version' : self.g2p_version
-                            }
-                        }
-                    }
-
                     # Add literature provenance if there are PMIDs
                     if len(pmids) != 0:
                         provenance_type["literature"] = {
                             'references' : self.get_pub_array(pmids.split(";"))
                         }
-
-                    # *** General properties ***
-                    access_level = "public"
-                    sourceID = "gene2phenotype"
-                    validated_against_schema_version = self.schema_version
 
                     # *** Target info ***
                     target = {

--- a/modules/Gene2Phenotype.py
+++ b/modules/Gene2Phenotype.py
@@ -276,15 +276,6 @@ class G2P(RareDiseaseMapper):
                             '{} is not a recognised G2P mutation consequence, ignoring the value'.format(mutation_consequence))
                         functional_consequence = None
 
-
-                    # Linkout
-                    linkout = [
-                        {
-                            'url' : 'http://www.ebi.ac.uk/gene2phenotype/search?panel=ALL&search_term=%s' % (gene_symbol,),
-                            'nice_name' : 'Gene2Phenotype%s' % (gene_symbol)
-                        }
-                    ]
-
                     evidence = {
                         'datasourceId': 'gene2phenotype',
                         'datatypeId': 'genetic_literature',

--- a/modules/Gene2Phenotype.py
+++ b/modules/Gene2Phenotype.py
@@ -238,7 +238,7 @@ class G2P(RareDiseaseMapper):
                         'diseaseFromSourceId': disease_mim,
                         'diseaseFromSourceMappedId': ontoma.interface.make_uri(disease_mapping['id']).split("/")[-1],
                         'confidence': confidence,
-                        'studyId': expert_panel_name
+                        'studyId': panel
                     }
 
                     # Add literature provenance if there are PMIDs

--- a/modules/Gene2Phenotype.py
+++ b/modules/Gene2Phenotype.py
@@ -279,19 +279,19 @@ def main():
     parser = argparse.ArgumentParser(description='Parse Gene2Phenotype gene-disease files downloaded from https://www.ebi.ac.uk/gene2phenotype/downloads/')
     parser.add_argument('-d', '--dd_panel',
                         help='DD panel file downloaded from https://www.ebi.ac.uk/gene2phenotype/downloads',
-                        type=str, default=Config.G2P_DD_FILENAME)
+                        type=str)
     parser.add_argument('-e', '--eye_panel',
                         help='Eye panel file downloaded from https://www.ebi.ac.uk/gene2phenotype/downloads',
-                        type=str, default=Config.G2P_eye_FILENAME)
+                        type=str)
     parser.add_argument('-k', '--skin_panel',
                         help='Skin panel file downloaded from https://www.ebi.ac.uk/gene2phenotype/downloads',
-                        type=str, default=Config.G2P_skin_FILENAME)
+                        type=str)
     parser.add_argument('-c', '--cancer_panel',
                         help='Cancer panel file downloaded from https://www.ebi.ac.uk/gene2phenotype/downloads',
-                        type=str, default=Config.G2P_cancer_FILENAME)
+                        type=str)
     parser.add_argument('-o', '--output_file',
                         help='Name of evidence file. It uses the value of G2P_EVIDENCE_FILENAME in setting.py if not specified',
-                        type=str, default=Config.G2P_EVIDENCE_FILENAME)
+                        type=str)
     parser.add_argument('-u', '--unmapped_diseases_file',
                         help='If specified, the diseases not mapped to EFO will be stored in this file',
                         type=str, default=False)

--- a/modules/Gene2Phenotype.py
+++ b/modules/Gene2Phenotype.py
@@ -9,6 +9,7 @@ import csv
 import gzip
 import requests
 import argparse
+import json
 
 G2P_mutationCsq2functionalCsq = {
     'loss of function' : 'SO_0002054', #loss_of_function_variant
@@ -254,6 +255,8 @@ class G2P(RareDiseaseMapper):
                     else:
                         self._logger.error( '{} is not a recognised G2P mutation consequence, ignoring the value'.format(mutation_consequence))
 
+                    self.evidence_strings.append(evidence)
+
             self._logger.info(f"Processed {c} diseases, mapped {total_efo}\n")
 
     def write_evidence_strings(self, filename):
@@ -262,7 +265,8 @@ class G2P(RareDiseaseMapper):
             n = 0
             for evidence_string in self.evidence_strings:
                 n += 1
-                tp_file.write(evidence_string.serialize() + "\n")
+                json.dump(evidence_string, tp_file)
+                tp_file.write("\n")
             self._logger.info(f"{n} evidence strings saved.\n")
 
     def write_unmapped_diseases(self, filename):

--- a/modules/Gene2Phenotype.py
+++ b/modules/Gene2Phenotype.py
@@ -24,11 +24,10 @@ G2P_mutationCsq2functionalCsq = {
 
 
 class G2P():
-    def __init__(self, g2p_version):
+    def __init__(self):
         super(G2P, self).__init__()
         self.evidence_strings = list()
         self.unmapped_diseases = set()
-        self.g2p_version = g2p_version
 
         # Configure logging
         # Create logger
@@ -293,9 +292,6 @@ def main():
     parser.add_argument('-u', '--unmapped_diseases_file',
                         help='If specified, the diseases not mapped to EFO will be stored in this file',
                         type=str, default=False)
-    parser.add_argument('-v', '--g2p_version',
-                        help='Version of the Gene2Phenotype data used. If not available please use the date in which the data was downloaded in YYYY-MM-DD format',
-                        type=str, required=True)
 
     args = parser.parse_args()
     # Get parameters
@@ -305,9 +301,8 @@ def main():
     cancer_file = args.cancer_panel
     outfile = args.output_file
     unmapped_diseases_file = args.unmapped_diseases_file
-    g2p_version = args.g2p_version
 
-    g2p = G2P(g2p_version=g2p_version)
+    g2p = G2P()
     g2p.process_g2p(dd_file, eye_file, skin_file, cancer_file, outfile, unmapped_diseases_file)
 
 if __name__ == "__main__":

--- a/modules/Gene2Phenotype.py
+++ b/modules/Gene2Phenotype.py
@@ -12,14 +12,6 @@ import requests
 import datetime
 import argparse
 
-__copyright__  = "Copyright 2014-2020, Open Targets"
-__credits__    = ["Gautier Koscielny", "ChuangKee Ong", "Michaela Spitzer", "Asier Gonzalez" ]
-__license__    = "Apache 2.0"
-__version__    = "1.3.0"
-__maintainer__ = "Open Targets Data Team"
-__email__      = ["data@opentargets.org"]
-__status__     = "Production"
-
 G2P_confidence2score = {
     'confirmed' : 1,
     'probable': 0.5,

--- a/modules/Gene2Phenotype.py
+++ b/modules/Gene2Phenotype.py
@@ -8,7 +8,6 @@ import logging
 import csv
 import gzip
 import requests
-import datetime
 import argparse
 
 G2P_confidence2score = {
@@ -257,14 +256,6 @@ class G2P(RareDiseaseMapper):
                 confidence = row["DDD category"]
                 pmids = row["pmids"]
                 panel = row["panel"]
-
-                date = row["gene disease pair entry date"]
-                # Handle missing dates ("No date" in file)
-                try:
-                    date = datetime.datetime.strptime(date, "%Y-%m-%d %H:%M:%S").isoformat()
-                except ValueError:
-                    date = None
-
 
                 gene_symbol.rstrip()
 

--- a/modules/Gene2Phenotype.py
+++ b/modules/Gene2Phenotype.py
@@ -230,19 +230,6 @@ class G2P(RareDiseaseMapper):
 
                     self._logger.info(f"{gene_symbol}, {target}, '{disease_name}', {disease_mapping['id']}")
 
-                    # Ignore allelic requirement if it's empty string
-                    if not allelic_requirement:
-                        allelic_requirement = None
-                        self._logger.warn('Empty allelic requirement')
-
-                    # Functional consequence based on mutation consequence field
-                    if mutation_consequence in G2P_mutationCsq2functionalCsq:
-                        functional_consequence = G2P_mutationCsq2functionalCsq[mutation_consequence]
-                    else:
-                        self._logger.error(
-                            '{} is not a recognised G2P mutation consequence, ignoring the value'.format(mutation_consequence))
-                        functional_consequence = None
-
                     evidence = {
                         'datasourceId': 'gene2phenotype',
                         'datatypeId': 'genetic_literature',
@@ -250,7 +237,6 @@ class G2P(RareDiseaseMapper):
                         'diseaseFromSource': disease_name,
                         'diseaseFromSourceId': disease_mim,
                         'diseaseFromSourceMappedId': ontoma.interface.make_uri(disease_mapping['id']).split("/")[-1],
-                        'allelicRequirements': [mode_of_inheritance],
                         'confidence': confidence,
                         'studyId': expert_panel_name
                     }
@@ -258,6 +244,15 @@ class G2P(RareDiseaseMapper):
                     # Add literature provenance if there are PMIDs
                     if len(pmids) != 0:
                         evidence['literature'] = pmids.split(";")
+
+                    # Ignore allelic requirement if it's empty string
+                    evidence['allelicRequirements'] = [allelic_requirement] if allelic_requirement else self._logger.warn('Empty allelic requirement, ignoring the value')
+
+                    # Assign SO code based on mutation consequence field
+                    if mutation_consequence in G2P_mutationCsq2functionalCsq:
+                        evidence['variantFunctionalConsequenceId'] = G2P_mutationCsq2functionalCsq[mutation_consequence]
+                    else:
+                        self._logger.error( '{} is not a recognised G2P mutation consequence, ignoring the value'.format(mutation_consequence))
 
             self._logger.info(f"Processed {c} diseases, mapped {total_efo}\n")
 

--- a/modules/Gene2Phenotype.py
+++ b/modules/Gene2Phenotype.py
@@ -1,12 +1,9 @@
 from settings import Config
 import ontoma
 
-import python_jsonschema_objects as pjo
-
 import logging
 import csv
 import gzip
-import requests
 import argparse
 import json
 

--- a/modules/Gene2Phenotype.py
+++ b/modules/Gene2Phenotype.py
@@ -351,42 +351,17 @@ class G2P(RareDiseaseMapper):
                     ]
 
                     evidence = {
-                        'is_associated' : True,
-                        'confidence' : confidence,
-                        'allelic_requirement' : allelic_requirement,
-                        'functional_consequence' : functional_consequence,
-                        'evidence_codes' : ["http://purl.obolibrary.org/obo/ECO_0000204"],
-                        'provenance_type' : provenance_type,
-                        'date_asserted' : date,
-                        'resource_score' : resource_score,
-                        'urls' : linkout
+                        'datasourceId': 'gene2phenotype',
+                        'datatypeId': 'genetic_literature',
+                        'targetFromSourceId': gene_symbol,
+                        'diseaseFromSource': disease_name,
+                        'diseaseFromSourceId': disease_id,
+                        'diseaseFromSourceMappedId': ontoma.interface.make_uri(efo_mapping['id']).split("/")[-1],
+                        'allelicRequirements': [mode_of_inheritance],
+                        'confidence': classification,
+                        'literature': ,
+                        'studyId': expert_panel_name
                     }
-                    # *** unique_association_fields ***
-                    unique_association_fields = {
-                        'target_id' : ensembl_iri,
-                        'original_disease_label' : disease_name,
-                        'disease_id' : disease_mapping['id'],
-                        'gene_panel': panel,
-                        "mutation_consequence": mutation_consequence,
-                        "allelic_requirement": allelic_requirement
-                    }
-
-
-                    try:
-                        evidence = self.evidence_builder.Opentargets(
-                            type = type,
-                            access_level = access_level,
-                            sourceID = sourceID,
-                            evidence = evidence,
-                            target = target,
-                            disease = disease_info,
-                            unique_association_fields = unique_association_fields,
-                            validated_against_schema_version = validated_against_schema_version
-                        )
-                        self.evidence_strings.append(evidence)
-                    except:
-                        self._logger.warning('Evidence generation failed for row: {}'.format(c))
-                        raise
 
             self._logger.info(f"Processed {c} diseases, mapped {total_efo}\n")
 

--- a/modules/Gene2Phenotype.py
+++ b/modules/Gene2Phenotype.py
@@ -1,5 +1,4 @@
 from settings import Config
-from common.RareDiseasesUtils import RareDiseaseMapper
 import ontoma
 
 import python_jsonschema_objects as pjo
@@ -27,7 +26,7 @@ G2P_mutationCsq2functionalCsq = {
 
 
 
-class G2P(RareDiseaseMapper):
+class G2P():
     def __init__(self, g2p_version):
         super(G2P, self).__init__()
         self.evidence_strings = list()
@@ -175,8 +174,6 @@ class G2P(RareDiseaseMapper):
                 return
 
     def process_g2p(self, dd_file, eye_file, skin_file, cancer_file, evidence_file, unmapped_diseases_filename):
-
-        self.get_omim_to_efo_mappings()
 
         # Parser DD file
         self._logger.info("Started parsing DD file")

--- a/modules/Gene2Phenotype.py
+++ b/modules/Gene2Phenotype.py
@@ -36,7 +36,7 @@ G2P_mutationCsq2functionalCsq = {
 
 
 class G2P(RareDiseaseMapper):
-    def __init__(self, g2p_version, schema_version=Config.VALIDATED_AGAINST_SCHEMA_VERSION):
+    def __init__(self, g2p_version):
         super(G2P, self).__init__()
         self.evidence_strings = list()
         self.unmapped_diseases = set()
@@ -59,23 +59,6 @@ class G2P(RareDiseaseMapper):
 
         # Add ch to handler
         self._logger.addHandler(ch)
-
-        # Build JSON schema url from version
-        self.schema_version = schema_version
-        schema_url = "https://raw.githubusercontent.com/opentargets/json_schema/" + self.schema_version + "/draft4_schemas/opentargets.json"
-        self._logger.info('Loading JSON schema at {}'.format(schema_url))
-
-        # Initialize json builder based on the schema:
-        try:
-            r = requests.get(schema_url)
-            r.raise_for_status()
-            json_schema = r.json()
-            self.builder = pjo.ObjectBuilder(json_schema)
-            self.evidence_builder = self.builder.build_classes()
-            self.schema_version = schema_version
-        except requests.exceptions.HTTPError as e:
-            self._logger.error('Invalid JSON schema version')
-            raise e
 
         # Create OnToma object
         self.ontoma = ontoma.interface.OnToma()
@@ -428,9 +411,6 @@ def main():
 
     # Parse CLI arguments
     parser = argparse.ArgumentParser(description='Parse Gene2Phenotype gene-disease files downloaded from https://www.ebi.ac.uk/gene2phenotype/downloads/')
-    parser.add_argument('-s', '--schema_version',
-                        help='JSON schema version to use, e.g. 1.6.8. It must be branch or a tag available in https://github.com/opentargets/json_schema',
-                        type=str, required=True)
     parser.add_argument('-d', '--dd_panel',
                         help='DD panel file downloaded from https://www.ebi.ac.uk/gene2phenotype/downloads',
                         type=str, default=Config.G2P_DD_FILENAME)
@@ -455,7 +435,6 @@ def main():
 
     args = parser.parse_args()
     # Get parameters
-    schema_version = args.schema_version
     dd_file = args.dd_panel
     eye_file = args.eye_panel
     skin_file = args.skin_panel
@@ -464,7 +443,7 @@ def main():
     unmapped_diseases_file = args.unmapped_diseases_file
     g2p_version = args.g2p_version
 
-    g2p = G2P(schema_version=schema_version, g2p_version=g2p_version)
+    g2p = G2P(g2p_version=g2p_version)
     g2p.process_g2p(dd_file, eye_file, skin_file, cancer_file, outfile, unmapped_diseases_file)
 
 if __name__ == "__main__":

--- a/modules/Gene2Phenotype.py
+++ b/modules/Gene2Phenotype.py
@@ -257,7 +257,6 @@ class G2P(RareDiseaseMapper):
                 pmids = row["pmids"]
                 panel = row["panel"]
 
-                gene_symbol.rstrip()
 
                 # Map disease to ontology terms
                 disease_mapping = self.map_disease_name_to_ontology(disease_name, disease_mim)
@@ -271,15 +270,6 @@ class G2P(RareDiseaseMapper):
                         provenance_type["literature"] = {
                             'references' : self.get_pub_array(pmids.split(";"))
                         }
-
-                    # *** Target info ***
-                    target = {
-                        'id' : ensembl_iri,
-                        'activity' : "http://identifiers.org/cttv.activity/unknown",
-                        'target_type' : "http://identifiers.org/cttv.target/gene_evidence",
-                        'target_name' : gene_symbol
-                    }
-                    # http://www.ontobee.org/ontology/ECO?iri=http://purl.obolibrary.org/obo/ECO_0000204 -- An evidence type that is based on an assertion by the author of a paper, which is read by a curator.
 
                     # *** Disease info ***
                     disease_info = {
@@ -325,7 +315,7 @@ class G2P(RareDiseaseMapper):
                     evidence = {
                         'datasourceId': 'gene2phenotype',
                         'datatypeId': 'genetic_literature',
-                        'targetFromSourceId': gene_symbol,
+                        'targetFromSourceId': gene_symbol.rstrip(),
                         'diseaseFromSource': disease_name,
                         'diseaseFromSourceId': disease_id,
                         'diseaseFromSourceMappedId': ontoma.interface.make_uri(efo_mapping['id']).split("/")[-1],

--- a/modules/Gene2Phenotype.py
+++ b/modules/Gene2Phenotype.py
@@ -173,33 +173,6 @@ class G2P(RareDiseaseMapper):
                 self._logger.info(f"No match for '{disease_name}' in MONDO")
                 return
 
-    def get_pub_array(self, pub_list):
-        '''
-        Takes a list of PMIDs and returns a list of reference dictionaries
-
-        Args:
-            pub_list (list): List of PMIDs extracted from the "pmids column"
-
-        Returns:
-            list: List of dictionaries containing the URL to the PubMed abstract
-        '''
-
-        pub_array = []
-
-        # If there were no pubmed ids there is one empty iten in the array
-        for publication in pub_list:
-            if len(publication) == 0:
-                pub_dict = {
-                    "lit_id": None
-                }
-                pub_array.append(pub_dict)
-            else:
-                pub_dict = {
-                    "lit_id": f"http://europepmc.org/abstract/MED/{publication}"
-                }
-                pub_array.append(pub_dict)
-        return pub_array
-
     def process_g2p(self, dd_file, eye_file, skin_file, cancer_file, evidence_file, unmapped_diseases_filename):
 
         self.get_omim_to_efo_mappings()
@@ -257,12 +230,6 @@ class G2P(RareDiseaseMapper):
 
                     self._logger.info(f"{gene_symbol}, {target}, '{disease_name}', {disease_mapping['id']}")
 
-                    # Add literature provenance if there are PMIDs
-                    if len(pmids) != 0:
-                        provenance_type["literature"] = {
-                            'references' : self.get_pub_array(pmids.split(";"))
-                        }
-
                     # Ignore allelic requirement if it's empty string
                     if not allelic_requirement:
                         allelic_requirement = None
@@ -285,9 +252,12 @@ class G2P(RareDiseaseMapper):
                         'diseaseFromSourceMappedId': ontoma.interface.make_uri(disease_mapping['id']).split("/")[-1],
                         'allelicRequirements': [mode_of_inheritance],
                         'confidence': confidence,
-                        'literature': ,
                         'studyId': expert_panel_name
                     }
+
+                    # Add literature provenance if there are PMIDs
+                    if len(pmids) != 0:
+                        evidence['literature'] = pmids.split(";")
 
             self._logger.info(f"Processed {c} diseases, mapped {total_efo}\n")
 

--- a/modules/Gene2Phenotype.py
+++ b/modules/Gene2Phenotype.py
@@ -10,14 +10,6 @@ import gzip
 import requests
 import argparse
 
-G2P_confidence2score = {
-    'confirmed' : 1,
-    'probable': 0.5,
-    'possible' : 0.25,
-    'both RD and IF' : 1,
-    'child IF': 1
-}
-
 G2P_mutationCsq2functionalCsq = {
     'loss of function' : 'SO_0002054', #loss_of_function_variant
     'all missense/in frame' : 'SO_0001650', #inframe_variant
@@ -271,19 +263,6 @@ class G2P(RareDiseaseMapper):
                             'references' : self.get_pub_array(pmids.split(";"))
                         }
 
-                    # *** Evidence info ***
-                    # Score based on mutational consequence
-                    if confidence in G2P_confidence2score:
-                        score = G2P_confidence2score[confidence]
-                    else:
-                        self._logger.error('{} is not a recognised G2P confidence, assigning an score of 0'.format(confidence))
-                        score = 0
-
-                    resource_score = {
-                        'type': "probability",
-                        'value': score
-                    }
-
                     # Ignore allelic requirement if it's empty string
                     if not allelic_requirement:
                         allelic_requirement = None
@@ -314,7 +293,7 @@ class G2P(RareDiseaseMapper):
                         'diseaseFromSourceId': disease_mim,
                         'diseaseFromSourceMappedId': ontoma.interface.make_uri(disease_mapping['id']).split("/")[-1],
                         'allelicRequirements': [mode_of_inheritance],
-                        'confidence': classification,
+                        'confidence': confidence,
                         'literature': ,
                         'studyId': expert_panel_name
                     }

--- a/modules/Gene2Phenotype.py
+++ b/modules/Gene2Phenotype.py
@@ -222,7 +222,7 @@ class G2P():
                 if disease_mapping:
                     total_efo +=1
 
-                    self._logger.info(f"{gene_symbol}, {target}, '{disease_name}', {disease_mapping['id']}")
+                    self._logger.info(f"{gene_symbol}, {gene_symbol}, '{disease_name}', {disease_mapping['id']}")
 
                     evidence = {
                         'datasourceId': 'gene2phenotype',

--- a/settings.py
+++ b/settings.py
@@ -78,13 +78,6 @@ class Config:
     PHEWAS_CATALOG_EVIDENCE_FILENAME = f"phewas_catalog-{datetime.today().strftime('%Y-%m-%d')}.json"
     PHEWAS_CATALOG_W_CONSEQUENCES = 'https://storage.googleapis.com/otar000-evidence_input/PheWAS/data_files/phewas_w_consequences.csv'
 
-    # Gene2Phenotype
-    #G2P_FILENAME = 'DDG2P.csv.gz'
-    G2P_DD_FILENAME = file_or_resource('DDG2P_2_4_2020.csv.gz')
-    G2P_eye_FILENAME = file_or_resource('EyeG2P_26_3_2020.csv.gz')
-    G2P_skin_FILENAME = file_or_resource('SkinG2P_26_3_2020.csv.gz')
-    G2P_cancer_FILENAME = file_or_resource('CancerG2P_26_3_2020.csv.gz')
-    G2P_EVIDENCE_FILENAME = 'gene2phenotype-19-08-2019.json'
 
     # IntoGEN
     INTOGEN_DRIVER_GENES_FILENAME = file_or_resource('intogen_Compendium_Cancer_Genes.tsv')


### PR DESCRIPTION
Revamp of the Gene2Phenotype parser to align evidence strings with new schema. This is the summary of the changes made:

- JSON schema is NOT loaded
- Gene symbols are NOT mapped to Ensembl
- Evidence strings are stored as dictionaries and serialised as JSON
- Unique association fields have been removed because they are now controlled by the ETL pipeline.
- The script metadata has been removed from the code
- The scoring based on the classification/confidence has been removed.
- The mutation consequence is stored in `variantFunctionalConsequenceId`

Closes opentargets/platform#1279