### PR TITLE
Adding beta to parser

### DIFF
--- a/modules/GeneticsPortal.py
+++ b/modules/GeneticsPortal.py
@@ -122,7 +122,7 @@ def main():
         #     .otherwise(col('pval'))
         # )
         # Keep required fields
-        .select('study_id', 'chrom', 'pos', 'ref', 'alt', 
+        .select('study_id', 'chrom', 'pos', 'ref', 'alt', 'beta', 'beta_ci_lower', 'beta_ci_upper',
             'pval_mantissa', 'pval_exponent','odds_ratio','oddsr_ci_lower', 'oddsr_ci_upper')
     )
 
@@ -241,9 +241,15 @@ def main():
             col('sample_size').alias('studySampleSize'),
             col('pval_mantissa').alias('pValueMantissa'),
             col('pval_exponent').alias('pValueExponent'),
+
             col('odds_ratio').alias('oddsRatio'),
-            col('oddsr_ci_lower').alias('confidenceIntervalLower'),
-            col('oddsr_ci_upper').alias('confidenceIntervalUpper'),
+            col('oddsr_ci_lower').alias('oddsRatioConfidenceIntervalLower'),
+            col('oddsr_ci_upper').alias('oddsRatioConfidenceIntervalUpper'),
+            
+            col('beta').alias('beta'),
+            col('beta_ci_lower').alias('betaConfidenceIntervalLower'),
+            col('beta_ci_upper').alias('betaConfidenceIntervalUpper'),
+
             col('y_proba_full_model').alias('resourceScore'),
             col('rsid').alias('variantRsId'),
             concat_ws('_', col('chrom'),col('pos'),col('alt'),col('ref')).alias('variantId'),


### PR DESCRIPTION
Adding beta to genetics portal evidence. This is the generated evidence when odds ratio and beta is given. Tried and script runs successfully. 

**beta is given:**
```json
{
  "datasourceId": "ot_genetics_portal",
  "datatypeId": "genetic_association",
  "targetFromSourceId": "ENSG00000067606",
  "diseaseFromSourceMappedId": "EFO_0004314",
  "publicationFirstAuthor": "UKB Neale v2",
  "publicationYear": 2018,
  "diseaseFromSource": "Forced expiratory volume in 1-second (fev1), predicted",
  "studyId": "NEALE2_20153_raw",
  "studySampleSize": 117241,
  "pValueMantissa": 5.802630000000002,
  "pValueExponent": -9,
  "beta": 0.00535037,
  "betaConfidenceIntervalLower": 0.0035493887200000007,
  "betaConfidenceIntervalUpper": 0.00715135128,
  "resourceScore": 0.1838376522064209,
  "variantRsId": "rs1692585",
  "variantId": "1_2241480_C_T",
  "variantFunctionalConsequenceId": "SO_0001628"
}
```

** Odds ratio is given:**

```json
{
  "datasourceId": "ot_genetics_portal",
  "datatypeId": "genetic_association",
  "targetFromSourceId": "ENSG00000172260",
  "diseaseFromSourceMappedId": "HP_0030838",
  "publicationFirstAuthor": "UKB Neale v2",
  "publicationYear": 2018,
  "diseaseFromSource": "Hip pain | pain type(s) experienced in last month",
  "studyId": "NEALE2_6159_6",
  "studySampleSize": 360391,
  "pValueMantissa": 1.67888,
  "pValueExponent": -8,
  "oddsRatio": 1.0542523393359726,
  "oddsRatioConfidenceIntervalLower": 1.035080370696677,
  "oddsRatioConfidenceIntervalUpper": 1.073779415068313,
  "resourceScore": 0.4853196144104004,
  "variantRsId": "rs2764508",
  "variantId": "1_72770331_C_T",
  "variantFunctionalConsequenceId": "SO_0001628"
}
```