### PR TITLE
Update Orphanet_573163 to EFO_1000453

### DIFF
--- a/resources/cancer2EFO_mappings.tsv
+++ b/resources/cancer2EFO_mappings.tsv
@@ -57,7 +57,7 @@ NSCLC	Non small cell lung cancer	EFO_0003060 	non-small cell lung cancer	Dataset
 NSPH	Nasopharyngeal cancer	EFO_0004252	nasopharyngeal neoplasm	Dataset from intOGen
 OS	Osteosarcoma	EFO_0000637	osteosarcoma	Dataset from intOGen
 PAIS	Pancreatic neuroendocrine cancer	EFO_0007416	pancreatic endocrine carcinoma	Dataset from intOGen
-PCPG	Pheochromocytoma and Paraganglioma	Orphanet_573163 	Pheochromocytoma-paraganglioma	Dataset from intOGen
+PCPG	Pheochromocytoma and Paraganglioma	EFO_1000453 	Pheochromocytoma-paraganglioma	Dataset from intOGen
 PIA	Pilocityc astrocytoma	EFO_0000272	astrocytoma	Dataset from intOGen
 RB	Retinoblastoma	Orphanet_790	Retinoblastoma	Dataset from intOGen
 RCCC	Renal clear cell carcinoma	EFO_0000349	clear cell renal carcinoma	Dataset from intOGen


### PR DESCRIPTION
The more specific mapping Orphanet_573163 is not included in EFO at the moment, hence leading to invalid evidence strings.
We are going back to the less specific mapping "Paraganglioma" until we know whether it is possible to bring Orphanet_573163 into EFO.