### PR TITLE
EPMC parser update

### DIFF
--- a/modules/EPMC.py
+++ b/modules/EPMC.py
@@ -84,11 +84,11 @@ def main(cooccurrenceFile, outputFile, local=False):
     )
 
     # Report on the number of diseases, targets and associations if loglevel == "debug" to avoid cost on computation time:
-    logging.info(f"Number of publications: {filtered_cooccurrence_df.select(pf.col('pmid')).distinct().count()}")
-    logging.info(f"Number of targets: {filtered_cooccurrence_df.select(pf.col('targetFromSourceId')).distinct().count()}")
-    logging.info(f"Number of diseases: {filtered_cooccurrence_df.select(pf.col('diseaseFromSourceMappedId')).distinct().count()}")
-    logging.info(f"Number of associations: {filtered_cooccurrence_df.select(pf.col('diseaseFromSourceMappedId'), pf.col('targetFromSourceId')).dropDuplicates().count()}")
-    logging.info(f"Number of publications without pubmed ID: {filtered_cooccurrence_df.filter(pf.col('pmid').isNull()).select('pmcid').distinct().count()}")
+    logging.debug(f"Number of publications: {filtered_cooccurrence_df.select(pf.col('pmid')).distinct().count()}")
+    logging.debug(f"Number of targets: {filtered_cooccurrence_df.select(pf.col('targetFromSourceId')).distinct().count()}")
+    logging.debug(f"Number of diseases: {filtered_cooccurrence_df.select(pf.col('diseaseFromSourceMappedId')).distinct().count()}")
+    logging.debug(f"Number of associations: {filtered_cooccurrence_df.select(pf.col('diseaseFromSourceMappedId'), pf.col('targetFromSourceId')).dropDuplicates().count()}")
+    logging.debug(f"Number of publications without pubmed ID: {filtered_cooccurrence_df.filter(pf.col('pmid').isNull()).select('pmcid').distinct().count()}")
 
     # Aggregating cooccurrence, get score apply filter:    
     aggregated_df = (

--- a/modules/EPMC.py
+++ b/modules/EPMC.py
@@ -72,8 +72,7 @@ def main(cooccurrenceFile, outputFile, local=False):
         .filter(
             (pf.col('type') == 'GP-DS') &  # Filter gene/protein - disease cooccurrence
             (pf.col('isMapped')) &  # Filtering for mapped cooccurrences
-            # Making sure at least the pmid or the pmcid is given:
-            (pf.col('pmid').isNotNull() | pf.col('pmcid').isNotNull()) &
+            (pf.col('publicationIdentifier').isNotNull()) &  # Making sure at least the pmid or the pmcid is given:
             (pf.length(pf.col('text')) < 600) &  # Exclude sentences with more than 600 characters
             (pf.col('label1').isin(EXCLUDED_TARGET_TERMS) == False)  # Excluding target labels from the exclusion list
         )
@@ -84,7 +83,7 @@ def main(cooccurrenceFile, outputFile, local=False):
     )
 
     # Report on the number of diseases, targets and associations if loglevel == "debug" to avoid cost on computation time:
-    logging.debug(f"Number of publications: {filtered_cooccurrence_df.select(pf.col('pmid')).distinct().count()}")
+    logging.debug(f"Number of publications: {filtered_cooccurrence_df.select(pf.col('publicationIdentifier')).distinct().count()}")
     logging.debug(f"Number of targets: {filtered_cooccurrence_df.select(pf.col('targetFromSourceId')).distinct().count()}")
     logging.debug(f"Number of diseases: {filtered_cooccurrence_df.select(pf.col('diseaseFromSourceMappedId')).distinct().count()}")
     logging.debug(f"Number of associations: {filtered_cooccurrence_df.select(pf.col('diseaseFromSourceMappedId'), pf.col('targetFromSourceId')).dropDuplicates().count()}")

--- a/modules/EPMC.py
+++ b/modules/EPMC.py
@@ -58,39 +58,45 @@ def main(cooccurrenceFile, outputFile, local=False):
         # Reading file:
         spark.read.parquet(cooccurrenceFile)
 
+        # Casting integer pmid column to string:
+        .withColumn("pmid", pf.col('pmid').cast(StringType()))
+
+        # publication identifier is a pmid if available otherwise pmcid
+        .withColumn(
+            'publicationIdentifier',
+            pf.when(pf.col('pmid').isNull(), pf.col('pmcid'))
+            .otherwise(pf.col('pmid'))
+        )
+
         # Filtering for disease/target cooccurrences:
         .filter(
             (pf.col('type') == 'GP-DS') &  # Filter gene/protein - disease cooccurrence
-            (pf.col('isMapped') == True) &  # Filtering for mapped cooccurrences
-            (pf.col('pmid').isNotNull()) &  # Excluding publications without pmid
+            (pf.col('isMapped')) &  # Filtering for mapped cooccurrences
             (pf.length(pf.col('text')) < 600) &  # Exclude sentences with more than 600 characters
             (pf.col('label1').isin(EXCLUDED_TARGET_TERMS) == False)  # Excluding target labels from the exclusion list
         )
+
         # Renaming columns:
         .withColumnRenamed('keywordId1', 'targetFromSourceId')
         .withColumnRenamed('keywordId2', 'diseaseFromSourceMappedId')
-        .withColumnRenamed('label1', 'targetFromSource')
-        .withColumnRenamed('label2', 'diseaseFromSource')
-
-        .withColumn('pmid_str_tmp', pf.col('pmid').cast(StringType()))
     )
 
     # Report on the number of diseases, targets and associations if loglevel == "debug" to avoid cost on computation time:
-    logging.debug(f"Number of publications: {filtered_cooccurrence_df.select(pf.col('pmid_str_tmp')).distinct().count()}")
-    logging.debug(f"Number of targets: {filtered_cooccurrence_df.select(pf.col('targetFromSourceId')).distinct().count()}")
-    logging.debug(f"Number of diseases: {filtered_cooccurrence_df.select(pf.col('diseaseFromSourceMappedId')).distinct().count()}")
-    logging.debug(f"Number of associations: {filtered_cooccurrence_df.select(pf.col('diseaseFromSourceMappedId'), pf.col('targetFromSourceId')).dropDuplicates().count()}")
+    logging.info(f"Number of publications: {filtered_cooccurrence_df.select(pf.col('pmid')).distinct().count()}")
+    logging.info(f"Number of targets: {filtered_cooccurrence_df.select(pf.col('targetFromSourceId')).distinct().count()}")
+    logging.info(f"Number of diseases: {filtered_cooccurrence_df.select(pf.col('diseaseFromSourceMappedId')).distinct().count()}")
+    logging.info(f"Number of associations: {filtered_cooccurrence_df.select(pf.col('diseaseFromSourceMappedId'), pf.col('targetFromSourceId')).dropDuplicates().count()}")
+    logging.info(f"Number of publications without pubmed ID: {filtered_cooccurrence_df.filter(pf.col('pmid').isNull()).select('pmcid').distinct().count()}")
 
     # Aggregating cooccurrence, get score apply filter:    
     aggregated_df = (
         filtered_cooccurrence_df
 
         # Aggregating data by publication, target and disease:
-        .groupBy(['pmid', 'targetFromSourceId', 'diseaseFromSourceMappedId'])
+        .groupBy(['publicationIdentifier', 'targetFromSourceId', 'diseaseFromSourceMappedId'])
         .agg(
-            pf.first(pf.col('targetFromSource')).alias('targetFromSource'),
-            pf.first(pf.col('diseaseFromSource')).alias('diseaseFromSource'),
-            pf.collect_set(pf.col('pmid_str_tmp')).alias('literature'),
+            pf.first(pf.col('pmcid')).alias('pmcId'),
+            pf.collect_set(pf.col('pmid')).alias('literature'),
             pf.collect_set(
                 pf.struct(
                     pf.col('text'),
@@ -109,7 +115,7 @@ def main(cooccurrenceFile, outputFile, local=False):
     )
 
     # Report number of evidence:
-    logging.debug(f'Number of evidence: {aggregated_df.count()}')
+    logging.info(f'Number of evidence: {aggregated_df.count()}')
 
     # Final formatting and saving data:
     (
@@ -120,8 +126,8 @@ def main(cooccurrenceFile, outputFile, local=False):
         .withColumn('datatypeId', pf.lit('literature'))
 
         # Reorder columns:
-        .select(['datasourceId', 'datatypeId', 'targetFromSource', 'targetFromSourceId', 'resourceScore',
-                'diseaseFromSource', 'diseaseFromSourceMappedId', 'literature', 'textMiningSentences'])
+        .select(['datasourceId', 'datatypeId', 'targetFromSourceId', 'diseaseFromSourceMappedId','resourceScore',
+                 'literature', 'textMiningSentences', 'pmcId'])
 
         # Save output:
         .write.format('json').mode('overwrite').option('compression', 'gzip').save(outputFile)

--- a/modules/EPMC.py
+++ b/modules/EPMC.py
@@ -72,6 +72,8 @@ def main(cooccurrenceFile, outputFile, local=False):
         .filter(
             (pf.col('type') == 'GP-DS') &  # Filter gene/protein - disease cooccurrence
             (pf.col('isMapped')) &  # Filtering for mapped cooccurrences
+            # Making sure at least the pmid or the pmcid is given:
+            (pf.col('pmid').isNotNull() | pf.col('pmcid').isNotNull()) &
             (pf.length(pf.col('text')) < 600) &  # Exclude sentences with more than 600 characters
             (pf.col('label1').isin(EXCLUDED_TARGET_TERMS) == False)  # Excluding target labels from the exclusion list
         )

--- a/modules/EPMC.py
+++ b/modules/EPMC.py
@@ -95,7 +95,7 @@ def main(cooccurrenceFile, outputFile, local=False):
         # Aggregating data by publication, target and disease:
         .groupBy(['publicationIdentifier', 'targetFromSourceId', 'diseaseFromSourceMappedId'])
         .agg(
-            pf.first(pf.col('pmcid')).alias('pmcId'),
+            pf.collect_set(pf.col('pmcid')).alias('pmcIds'),
             pf.collect_set(pf.col('pmid')).alias('literature'),
             pf.collect_set(
                 pf.struct(
@@ -126,8 +126,8 @@ def main(cooccurrenceFile, outputFile, local=False):
         .withColumn('datatypeId', pf.lit('literature'))
 
         # Reorder columns:
-        .select(['datasourceId', 'datatypeId', 'targetFromSourceId', 'diseaseFromSourceMappedId','resourceScore',
-                 'literature', 'textMiningSentences', 'pmcId'])
+        .select(['datasourceId', 'datatypeId', 'targetFromSourceId', 'diseaseFromSourceMappedId',
+            'resourceScore', 'literature', 'textMiningSentences', 'pmcIds'])
 
         # Save output:
         .write.format('json').mode('overwrite').option('compression', 'gzip').save(outputFile)

--- a/modules/EPMC.py
+++ b/modules/EPMC.py
@@ -61,7 +61,7 @@ def main(cooccurrenceFile, outputFile, local=False):
         # Casting integer pmid column to string:
         .withColumn("pmid", pf.col('pmid').cast(StringType()))
 
-        # publication identifier is a pmid if available otherwise pmcid
+        # Publication identifier is a pmid if available, otherwise pmcid
         .withColumn(
             'publicationIdentifier',
             pf.when(pf.col('pmid').isNull(), pf.col('pmcid'))
@@ -128,8 +128,8 @@ def main(cooccurrenceFile, outputFile, local=False):
         .withColumn('datatypeId', pf.lit('literature'))
 
         # Reorder columns:
-        .select(['datasourceId', 'datatypeId', 'targetFromSourceId', 'diseaseFromSourceMappedId',
-            'resourceScore', 'literature', 'textMiningSentences', 'pmcIds'])
+        .select(['datasourceId', 'datatypeId', 'targetFromSourceId', 'diseaseFromSourceMappedId', 'resourceScore',
+                 'literature', 'textMiningSentences', 'pmcIds'])
 
         # Save output:
         .write.format('json').mode('overwrite').option('compression', 'gzip').save(outputFile)


### PR DESCRIPTION
In this branch there are two updates:

* From the epmc cooccurrence file we capture `pmcid` and is stored in the new field `pmcIds`. Which is a list.
* Now literature evidence is not discarded if pmid is not given if pmcid is present.
* `targetFromSource` and `diseaseFromSource` got removed from the evidence.

Example of the generated evidence where pmid is not given:

```json
{
  "datasourceId": "europepmc",
  "datatypeId": "literature",
  "targetFromSourceId": "ENSG00000226344",
  "diseaseFromSourceMappedId": "EFO_0000544",
  "resourceScore": 10,
  "literature": [],
  "textMiningSentences": [
    {
      "text": "In contrast to the observation with PLP, the amount of E2 recovered from the CHAPS-insoluble membrane fraction did not increase 20 h after infection, as compared with 5 h (Fig. 3 c).",
      "tStart": 55,
      "tEnd": 57,
      "dStart": 139,
      "dEnd": 148,
      "section": "results"
    },
    {
      "text": "To rule out the possibility that raft association at late postinfection times was due to an artifact caused by the viral expression system, we determined the raft association of the viral spike protein E2, 5 and 20 h after infection.",
      "tStart": 202,
      "tEnd": 204,
      "dStart": 223,
      "dEnd": 232,
      "section": "results"
    }
  ],
  "pmcIds": [
    "PMC2199249"
  ]
}
```