### PR TITLE
PhenoDigm evidence generation updates

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -191,14 +191,17 @@ rule progeny:
 ## phenodigm                : processes target-disease evidence querying the IMPC SOLR API
 rule phenodigm:
     output:
-        evidenceFile=GS.remote(f"{config['Phenodigm']['outputBucket']}/phenodigm-{timeStamp}.json.gz")
+        evidenceFile=GS.remote(f"{config['Phenodigm']['outputBucket']}/phenodigm-{timeStamp}.json.gz"),
+        mousePhenotypes=GS.remote(f"{config['Phenodigm']['outputBucket']}/phenodigm-{timeStamp}."
+                                  f"mousePhenotypes.json.gz")
     log:
         GS.remote(logFile)
     shell:
         """
         python modules/PhenoDigm.py \
             --cache-dir phenodigm_cache \
-            --output {output.evidenceFile}
+            --output-evidence {output.evidenceFile} \
+            --output-mouse-phenotypes {output.mousePhenotypes}
         """
 
 ## sysbio                   : processes key driver genes for specific diseases that have been curated from Systems Biology papers

--- a/modules/PhenoDigm.py
+++ b/modules/PhenoDigm.py
@@ -334,7 +334,7 @@ class PhenoDigm:
             os.rename(os.path.join(tmp_dir_name, json_chunks[0]), evidence_strings_filename)
 
 
-def main(cache_dir, output, score_cutoff, use_cached=False, log_file=None):
+def main(cache_dir, evidence_output, mouse_phenotypes_output, score_cutoff, use_cached=False, log_file=None):
     # Initialize the logger based on the provided log file. If no log file is specified, logs are written to STDERR.
     logging_config = {
         'level': logging.INFO,
@@ -358,14 +358,17 @@ def main(cache_dir, output, score_cutoff, use_cached=False, log_file=None):
     phenodigm.generate_phenodigm_evidence_strings(score_cutoff)
 
     logging.info('Collect and write the evidence strings.')
-    phenodigm.write_evidence_strings(output)
+    phenodigm.write_evidence_strings(evidence_output)
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     req = parser.add_argument_group('required arguments')
-    req.add_argument('--cache-dir', help='Directory to store the HGNC/MGI/SOLR cache files in.', required=True)
-    req.add_argument('--output', help='Name of the json.gz file to output the evidence strings into.', required=True)
+    req.add_argument('--cache-dir', required=True, help='Directory to store the HGNC/MGI/SOLR cache files in.')
+    req.add_argument('--output-evidence', required=True,
+                     help='Name of the json.gz file to output the evidence strings into.')
+    req.add_argument('--output-mouse-phenotypes', required=True,
+                     help='Name of the json.gz file to output the mousePhenotypes dataset into.')
     parser.add_argument('--score-cutoff', help=(
         'Discard model-disease associations with the `disease_model_avg_norm` score less than this value. The score '
         'ranges from 0 to 100.'
@@ -373,4 +376,5 @@ if __name__ == '__main__':
     parser.add_argument('--use-cached', help='Use the existing cache and do not update it.', action='store_true')
     parser.add_argument('--log-file', help='Optional filename to redirect the logs into.')
     args = parser.parse_args()
-    main(args.cache_dir, args.output, args.score_cutoff, args.use_cached, args.log_file)
+    main(args.cache_dir, args.output_evidence, args.output_mouse_phenotypes, args.score_cutoff, args.use_cached,
+         args.log_file)

--- a/modules/PhenoDigm.py
+++ b/modules/PhenoDigm.py
@@ -254,7 +254,7 @@ class PhenoDigm:
             for ontology_name in ('MP', 'HP')
         )
 
-        # Split lists of phenotypes in the 'mouse_model' and 'disease' tables and keep only the ID. For example, one row
+        # Split lists of phenotypes in the `mouse_model` and `disease` tables and keep only the ID. For example, one row
         # with 'MP:0001529 abnormal vocalization,MP:0002981 increased liver weight' becomes two rows with 'MP:0001529'
         # and 'MP:0002981'.
         model_mouse_phenotypes = (
@@ -334,7 +334,7 @@ class PhenoDigm:
             # Add the mouse gene mapping information. The mappings are not necessarily one to one, because a single MGI
             # can map to multiple Ensembl mouse genes. When this happens, join will handle the necessary explosions, and
             # a single row from the original table will generate multiple evidence strings. This adds the fields
-            # 'targetInModel' and 'targetInModelEnsemblId'.
+            # `targetInModel` and `targetInModelEnsemblId`.
             .join(self.mgi_gene_id_to_ensembl_mouse_gene_id, on='targetInModelMgiId', how='inner')
             # Add the human gene mapping information. This is added in two stages: MGI → HGNC → Ensembl human gene.
             # Similarly to mouse gene mappings, at each stage there is a possibility of a row explosion.
@@ -342,9 +342,9 @@ class PhenoDigm:
             .join(self.hgnc_gene_id_to_ensembl_human_gene_id, on='hgnc_gene_id', how='inner')  # 'targetFromSourceId'.
             .drop('hgnc_gene_id')
 
-            # Add all mouse phenotypes of the model → 'diseaseModelAssociatedModelPhenotypes'.
+            # Add all mouse phenotypes of the model → `diseaseModelAssociatedModelPhenotypes`.
             .join(all_mouse_phenotypes, on='model_id', how='left')
-            # Add the matched model/disease human phenotypes → 'diseaseModelAssociatedHumanPhenotypes'.
+            # Add the matched model/disease human phenotypes → `diseaseModelAssociatedHumanPhenotypes`.
             .join(matched_human_phenotypes, on=['model_id', 'disease_id'], how='left')
 
             # Add literature references → 'literature'.
@@ -353,7 +353,7 @@ class PhenoDigm:
             # Model ID adjustments. First, strip the trailing modifiers, where present. The original ID, used for table
             # joins, may look like 'MGI:6274930#hom#early', where the first part is the allele ID and the second
             # specifies the zygotic state. There can be several models for the same allele ID with different phenotypes.
-            # However, this information is also duplicated in 'biologicalModelGeneticBackground' (for example:
+            # However, this information is also duplicated in `biologicalModelGeneticBackground` (for example:
             # 'C57BL/6NCrl,Ubl7<em1(IMPC)Tcp> hom early'), so in this field we strip those modifiers.
             .withColumn(
                 'biologicalModelId',


### PR DESCRIPTION
Another round of updates from https://github.com/opentargets/platform/issues/1471.

Despite `mousePhenotypes` generation being of higher priority, it wasn't possible to fully implement before these changes are done.

* Separate MGI and Ensembl target identifiers in model
* Ingest, parse, process and join PubMed references
* Added stubs for `mousePhenotypes` generation and upload