### PR TITLE
Update disease mapping for SLAPEnrich

### DIFF
--- a/resources/cancer2EFO_mappings.tsv
+++ b/resources/cancer2EFO_mappings.tsv
@@ -16,6 +16,7 @@ COREAD	Colorectal adenocarcinoma	EFO_0000365	colorectal adenocarcinoma	Dataset f
 ALL	Acute lymphoblastic leukemia	EFO_0000220	acute lymphoblastic leukemia	Dataset from intOGen
 CLL	Chronic lymphoblastic leukemia	EFO_0000095	chronic lymphocytic leukemia	Dataset from intOGen
 DLBCL	Diffuse large B-cell lymphoma	EFO_0000403	diffuse large B-cell lymphoma	Dataset from intOGen
+DLBC	Diffuse large B-cell lymphoma	EFO_0000403	diffuse large B-cell lymphoma	Dataset from intOGen
 ESCA	Esophageal cancer	MONDO_0007576	esophageal cancer	Dataset from intOGen
 GBM	Glioblastoma	EFO_0000519	glioblastoma multiforme	Dataset from intOGen
 LAML	Acute Myeloid Leukemia	EFO_0000222	acute myeloid leukemia	TCGA study abbreviations table


### PR DESCRIPTION
The typo I mentioned in https://github.com/opentargets/evidence_datasource_parsers/commit/33ce8fe2ee30ab8070ffadce84b8c943f6579586 was not such.

intOGen and SLAPenrich both represent the seme disease (Diffuse large B-cell lymphoma / EFO_0000403) with two different acronyms: `DLBCL` and `DLBC` respectively.

When I changed the mapping file from DLBCL to DLBC to solve the unmapped intogen label, I introduced the bug where the SLAPenrich one wouldn't be matched.

I've just added another row to account for both representations.