### PR TITLE
Enhancement: remove obsolete from disease label

### DIFF
--- a/common/ontology.py
+++ b/common/ontology.py
@@ -25,7 +25,7 @@ def _simple_retry(func, **kwargs):
 
 def _ontoma_udf(row, ontoma_instance):
     """Try to map first by disease name (because that branch of OnToma is more stable), then by disease ID."""
-    disease_name = row['diseaseFromSource']
+    disease_name = row['diseaseFromSource'].replace('obsolete ', '')
     disease_id = row['diseaseFromSourceId'].replace('_', ':') if row['diseaseFromSourceId'] else None
     mappings = []
     if disease_name:


### PR DESCRIPTION
This PR removes the presence of the substring `obsolete` from the disease label so that OnToma can find an alternative mapping if the original one got obsoleted.

For example:
`MONDO:0009427` is an obsolete term. Ontoma is not able to find a proper mapping for the label:
```
In [88]: otmap.find_term('obsolete infantile hypophosphatasia')
INFO     - ontoma.interface - Processed: obsolete infantile hypophosphatasia → []
INFO:ontoma.interface:Processed: obsolete infantile hypophosphatasia → []
```

If the `obsolete` is removed, an alternative term is found:
```
In [89]: otmap.find_term('infantile hypophosphatasia')
INFO     - ontoma.interface - Processed: infantile hypophosphatasia → [OnTomaResult(query='infantile hypophosphatasia', id_normalised='ORDO:247651', id_ot_schema='Orphanet_247651', id_full_uri='http://www.orpha.net/ORDO/Orphanet_247651', label='infantile hypophosphatasia')]
INFO:ontoma.interface:Processed: infantile hypophosphatasia → [OnTomaResult(query='infantile hypophosphatasia', id_normalised='ORDO:247651', id_ot_schema='Orphanet_247651', id_full_uri='http://www.orpha.net/ORDO/Orphanet_247651', label='infantile hypophosphatasia')]
Out[89]: [OnTomaResult(query='infantile hypophosphatasia', id_normalised='ORDO:247651', id_ot_schema='Orphanet_247651', id_full_uri='http://www.orpha.net/ORDO/Orphanet_247651', label='infantile hypophosphatasia')]
```


