### PR TITLE
Add projectId to OTG

### DIFF
--- a/modules/GeneticsPortal.py
+++ b/modules/GeneticsPortal.py
@@ -131,6 +131,15 @@ def main():
             col('n_initial').alias('sample_size')  # Rename to sample size
         )
 
+        # Assign project based on the study author information
+        .withColumn(
+            'projectId',
+            when(col('publicationFirstAuthor').contains('FINNGEN'), 'FINNGEN')
+            .when(col('publicationFirstAuthor').contains('UKB Neale'), 'NEALE')
+            .when(col('publicationFirstAuthor').contains('UKB SAIGE'), 'SAIGE')
+            .otherwise('GCST')
+        )
+
         # Warning! Not all studies have an EFO annotated. Also, some have
         # multiple EFOs! We need to decide a strategy to deal with these.
 

--- a/modules/GeneticsPortal.py
+++ b/modules/GeneticsPortal.py
@@ -249,6 +249,7 @@ def main():
             col('efo').alias('diseaseFromSourceMappedId'),
             col('literature'),
             col('pub_author').alias('publicationFirstAuthor'),
+            'projectId',
             substring(col('pub_date'), 1, 4).cast(IntegerType()).alias('publicationYear'),
             col('trait_reported').alias('diseaseFromSource'),
             col('study_id').alias('studyId'),


### PR DESCRIPTION
The current version of the parser lacks the logic to infer the source of an OT Genetics study.
I'm adding that by processing the authors of the studies.