### PR TITLE
Updating the TEP parser

### DIFF
--- a/modules/TEP.py
+++ b/modules/TEP.py
@@ -5,12 +5,14 @@ import argparse
 import logging
 import sys
 
-from common.evidence import detect_spark_memory_limit, write_evidence_strings
 from pyspark import SparkFiles
 from pyspark.conf import SparkConf
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import (col, concat, explode, lit, lower,
                                    regexp_replace, split)
+
+from common.evidence import detect_spark_memory_limit, write_evidence_strings
+
 
 # The TEP dataset is made available by the SGC as a tab-separated file:
 TEPURL = 'https://www.thesgc.org/sites/default/files/fileuploads/available-teps.tsv'

--- a/modules/TEP.py
+++ b/modules/TEP.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Parser for Target Enabling Pacages (TEP)."""
+"""Parser for Target Enabling Packages (TEP) downloaded from the Structural Genomics Consortium website."""
 
 import argparse
 import logging
@@ -13,8 +13,6 @@ from pyspark import SparkFiles
 from common.evidence import detect_spark_memory_limit, write_evidence_strings
 
 
-'''
-This script retrieves TEP (target enabling package) from the structural genomics consoritum website.
 '''
 
 # The TEP dataset is made available by the SGC as a tab-separated file:
@@ -45,7 +43,7 @@ def main(outputFile: str) -> None:
 
     # Fetching and processing the TEP table and saved as a JSON file:
     TEP_df = (
-        spark.read.csv(SparkFiles.get("available-teps.tsv"), sep='\t', header=True)
+        spark.read.csv(SparkFiles.get(TEPURL.split('/')[-1]), sep='\t', header=True)
 
         # Generating TEP url from Gene column: SLC12A4/SLC12A6 -> https://www.thesgc.org/tep/SLC12A4SLC12A6
         .withColumn('url', concat(lit('https://www.thesgc.org/tep/'), regexp_replace(lower(col('Gene')), '/', '')))

--- a/modules/TEP.py
+++ b/modules/TEP.py
@@ -1,76 +1,70 @@
-import pandas as pd
-import requests
-from bs4 import BeautifulSoup, UnicodeDammit
+#!/usr/bin/env python3
+"""Parser for Target Enabling Pacages (TEP)."""
+
 import argparse
 import logging
-import logging.config
 import sys
 
+from pyspark.conf import SparkConf
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import explode, col, concat, lit, lower, regexp_replace,  split
+
+from common.evidence import detect_spark_memory_limit, write_evidence_strings
+
 
 '''
-This script retrieves TEP (target enabling package) from the structural genomics consoritum.
+This script retrieves TEP (target enabling package) from the structural genomics consoritum website.
 '''
 
-def retrieve_tep_table() -> pd.DataFrame:
-
-    def get_gene_name(row):
-        return row.findAll('td')[0].text.split('/')
-
-    def get_description(row):
-        return row.findAll('td')[1].text.strip()
-
-    def get_url(row):
-        gene_cell = row.findAll('td')[0]
-        tep_url = gene_cell.find('a').get('href')
-
-        if not tep_url.startswith('http'):
-            tep_url = 'https://www.thesgc.org' + tep_url
-
-        return tep_url
-
-    def get_therapeutic_area(row):
-        therapeutic_area = row.findAll('td')[2].text
-        return therapeutic_area
-
-    URL = 'https://www.thesgc.org/tep'
-
-    response = requests.get(URL)
-
-    html = response.text
-    uhtml = UnicodeDammit(html)
-
-    soup = BeautifulSoup(uhtml.unicode_markup, features='html.parser')
-
-    TEP_table = soup.findAll('table')[-1]
-
-    TEP_raw_data = []
-
-    for row in TEP_table.find('tbody').findAll('tr'):
-        TEP_raw_data.append({
-            'targetFromSourceId': get_gene_name(row),
-            'url': get_url(row),
-            'therapeuticArea': get_therapeutic_area(row),
-            'description': get_description(row)
-        })
-
-    return pd.DataFrame(TEP_raw_data).explode('targetFromSourceId')
+# The TEP dataset is made available by the SGC as a tab-separated file:
+TEPURL = 'https://www.thesgc.org/sites/default/files/fileuploads/available-teps.tsv'
 
 
 def main(outputFile: str) -> None:
 
-    # The TEP list compiled as dataframe:
-    tep_list = retrieve_tep_table()
-    logging.info(f'Number of TEPs retrieved: {len(tep_list)}')
-    logging.info(f'Number of unique gene symbols in the tep: {len(tep_list.targetFromSourceId.unique())}')
+    # Initialize spark session
+    spark_mem_limit = detect_spark_memory_limit()
+    spark_conf = (
+        SparkConf()
+        .set('spark.driver.memory', f'{spark_mem_limit}g')
+        .set('spark.executor.memory', f'{spark_mem_limit}g')
+        .set('spark.driver.maxResultSize', '0')
+        .set('spark.debug.maxToStringFields', '2000')
+        .set('spark.sql.execution.arrow.maxRecordsPerBatch', '500000')
+    )
+    spark = (
+        SparkSession.builder
+        .config(conf=spark_conf)
+        .config("spark.sql.broadcastTimeout", "36000")
+        .master('local[*]')
+        .getOrCreate()
+    )
 
-    if tep_list.targetFromSourceId.duplicated().any():
-        duplicated_targets = tep_list.loc[tep_list.targetFromSourceId.duplicated()]
-        logging.error(f'The following symbols were not unique: {duplicated_targets}')
-        raise ValueError('The target symbol list is expected to be unique! Check logs for deatils.')
+    spark.sparkContext.addFile("https://www.thesgc.org/sites/default/files/fileuploads/available-teps.tsv")
+
+    # Fetching and processing the TEP table and saved as a JSON file:
+    TEP_df = (
+        spark.read.csv(spark.SparkFiles.get("available-teps.tsv"), sep='\t', header=True)
+
+        # Generating TEP url from Gene column: SLC12A4/SLC12A6 -> https://www.thesgc.org/tep/SLC12A4SLC12A6
+        .withColumn('url', concat(lit('https://www.thesgc.org/tep/'), regexp_replace(lower(col('Gene')), '/', '')))
+
+        # Exploding TEPs, where multiple genes are given:
+        .withColumn('targetFromSourceId', explode(split(col('Gene'), '/')))
+
+        # Renaming columns:
+        .withColumnRenamed('Therapeutic Area', 'therapeuticArea')
+        .withColumnRenamed('Description', 'description')
+        .persist()
+    )
+
+    logging.info('TEP dataset has been downloaded and formatted.')
+    logging.info(f'Number of TEPs: {TEP_df.count()}')
+    logging.info(f'Number of unique genes: {TEP_df.select("targetFromSourceId").distinct().count()}')
 
     # Saving data:
-    logging.info(f'Saving data to {outputFile}.')
-    tep_list.to_json(outputFile, compression='infer', orient='records', lines=True)
+    write_evidence_strings(TEP_df, outputFile)
+    logging.info(f'TEP dataset is written to {outputFile}.')
 
 
 if __name__ == '__main__':

--- a/modules/TEP.py
+++ b/modules/TEP.py
@@ -31,7 +31,6 @@ def main(outputFile: str) -> None:
     spark = (
         SparkSession.builder
         .config(conf=spark_conf)
-        .config("spark.sql.broadcastTimeout", "36000")
         .master('local[*]')
         .getOrCreate()
     )

--- a/modules/TEP.py
+++ b/modules/TEP.py
@@ -7,7 +7,8 @@ import sys
 
 from pyspark.conf import SparkConf
 from pyspark.sql import SparkSession
-from pyspark.sql.functions import explode, col, concat, lit, lower, regexp_replace,  split
+from pyspark.sql.functions import explode, col, concat, lit, lower, regexp_replace, split
+from pyspark import SparkFiles
 
 from common.evidence import detect_spark_memory_limit, write_evidence_strings
 
@@ -44,7 +45,7 @@ def main(outputFile: str) -> None:
 
     # Fetching and processing the TEP table and saved as a JSON file:
     TEP_df = (
-        spark.read.csv(spark.SparkFiles.get("available-teps.tsv"), sep='\t', header=True)
+        spark.read.csv(SparkFiles.get("available-teps.tsv"), sep='\t', header=True)
 
         # Generating TEP url from Gene column: SLC12A4/SLC12A6 -> https://www.thesgc.org/tep/SLC12A4SLC12A6
         .withColumn('url', concat(lit('https://www.thesgc.org/tep/'), regexp_replace(lower(col('Gene')), '/', '')))
@@ -55,6 +56,9 @@ def main(outputFile: str) -> None:
         # Renaming columns:
         .withColumnRenamed('Therapeutic Area', 'therapeuticArea')
         .withColumnRenamed('Description', 'description')
+
+        # Dropping columns:
+        .drop(*['Gene', 'version', 'Date'])
         .persist()
     )
 

--- a/modules/TEP.py
+++ b/modules/TEP.py
@@ -13,7 +13,6 @@ from pyspark import SparkFiles
 from common.evidence import detect_spark_memory_limit, write_evidence_strings
 
 
-'''
 
 # The TEP dataset is made available by the SGC as a tab-separated file:
 TEPURL = 'https://www.thesgc.org/sites/default/files/fileuploads/available-teps.tsv'
@@ -39,7 +38,7 @@ def main(outputFile: str) -> None:
         .getOrCreate()
     )
 
-    spark.sparkContext.addFile("https://www.thesgc.org/sites/default/files/fileuploads/available-teps.tsv")
+    spark.sparkContext.addFile(TEPURL)
 
     # Fetching and processing the TEP table and saved as a JSON file:
     TEP_df = (

--- a/modules/TEP.py
+++ b/modules/TEP.py
@@ -5,14 +5,12 @@ import argparse
 import logging
 import sys
 
+from common.evidence import detect_spark_memory_limit, write_evidence_strings
+from pyspark import SparkFiles
 from pyspark.conf import SparkConf
 from pyspark.sql import SparkSession
-from pyspark.sql.functions import explode, col, concat, lit, lower, regexp_replace, split
-from pyspark import SparkFiles
-
-from common.evidence import detect_spark_memory_limit, write_evidence_strings
-
-
+from pyspark.sql.functions import (col, concat, explode, lit, lower,
+                                   regexp_replace, split)
 
 # The TEP dataset is made available by the SGC as a tab-separated file:
 TEPURL = 'https://www.thesgc.org/sites/default/files/fileuploads/available-teps.tsv'
@@ -42,7 +40,8 @@ def main(outputFile: str) -> None:
 
     # Fetching and processing the TEP table and saved as a JSON file:
     TEP_df = (
-        spark.read.csv(SparkFiles.get(TEPURL.split('/')[-1]), sep='\t', header=True)
+        spark.read.csv(SparkFiles.get(
+            TEPURL.split('/')[-1]), sep='\t', header=True)
 
         # Generating TEP url from Gene column: SLC12A4/SLC12A6 -> https://www.thesgc.org/tep/SLC12A4SLC12A6
         .withColumn('url', concat(lit('https://www.thesgc.org/tep/'), regexp_replace(lower(col('Gene')), '/', '')))
@@ -61,7 +60,8 @@ def main(outputFile: str) -> None:
 
     logging.info('TEP dataset has been downloaded and formatted.')
     logging.info(f'Number of TEPs: {TEP_df.count()}')
-    logging.info(f'Number of unique genes: {TEP_df.select("targetFromSourceId").distinct().count()}')
+    logging.info(
+        f'Number of unique genes: {TEP_df.select("targetFromSourceId").distinct().count()}')
 
     # Saving data:
     write_evidence_strings(TEP_df, outputFile)
@@ -71,9 +71,12 @@ def main(outputFile: str) -> None:
 if __name__ == '__main__':
 
     # Reading output file name from the command line:
-    parser = argparse.ArgumentParser(description='This script fetches TEP data from Structural Genomics Consortium.')
-    parser.add_argument('--output_file', '-o', type=str, help='Output file. gzipped JSON', required=True)
-    parser.add_argument('--log_file', type=str, help='File into which the logs are saved', required=False)
+    parser = argparse.ArgumentParser(
+        description='This script fetches TEP data from Structural Genomics Consortium.')
+    parser.add_argument('--output_file', '-o', type=str,
+                        help='Output file. gzipped JSON', required=True)
+    parser.add_argument('--log_file', type=str,
+                        help='File into which the logs are saved', required=False)
     args = parser.parse_args()
 
     # If no logfile is specified, logs are written to the standard error:


### PR DESCRIPTION
Thank to the communication initiated by @andrewhercules , the [Structural Genomics Consortium](https://www.thesgc.org/) made the Target Enabling Packages (TEPs) available through a downloadable tsv file. This allowed us the following changes:

* Instead of parsing fragile html files, we can directly read data from a properly formatted table.
* We could increase consistency across other datasource parsers by using PySpark in favour of Pandas. 
* Shared modules used imported from `common.evidence`

The stable url for the data is hardcoded into the script. I think adding to the configuration does not make sense at this point.