### PR TITLE
Gene2Phenotype updates

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -216,7 +216,7 @@ rule gene2Phenotype:
         ddPanel = HTTP.remote(config['Gene2Phenotype']['webSource_dd_panel']),
         eyePanel = HTTP.remote(config['Gene2Phenotype']['webSource_eye_panel']),
         skinPanel = HTTP.remote(config['Gene2Phenotype']['webSource_skin_panel']),
-        cancerPanel = HTTP.remote(config['Gene2Phenotype']['webSource_cancer_panel'])
+        cancerPanel = HTTP.remote(config['Gene2Phenotype']['webSource_cancer_panel']),
         cardiacPanel = HTTP.remote(config['Gene2Phenotype']['webSource_cardiac_panel'])
     params:
         cacheDir = config['global']['cacheDir'],
@@ -226,7 +226,7 @@ rule gene2Phenotype:
         eyeBucket = 'EyeG2P.csv.gz',
         skinBucket = 'SkinG2P.csv.gz',
         cancerBucket = 'CancerG2P.csv.gz',
-        cardiacBucket = 'CardiacG2P.csv.gz'
+        cardiacBucket = 'CardiacG2P.csv.gz',
         evidenceFile = 'gene2phenotype.json.gz'
     log:
         'log/gene2Phenotype.log'

--- a/Snakefile
+++ b/Snakefile
@@ -217,6 +217,7 @@ rule gene2Phenotype:
         eyePanel = HTTP.remote(config['Gene2Phenotype']['webSource_eye_panel']),
         skinPanel = HTTP.remote(config['Gene2Phenotype']['webSource_skin_panel']),
         cancerPanel = HTTP.remote(config['Gene2Phenotype']['webSource_cancer_panel'])
+        cardiacPanel = HTTP.remote(config['Gene2Phenotype']['webSource_cardiac_panel'])
     params:
         cacheDir = config['global']['cacheDir'],
         schema = f"{config['global']['schema']}/opentargets.json"
@@ -225,6 +226,7 @@ rule gene2Phenotype:
         eyeBucket = 'EyeG2P.csv.gz',
         skinBucket = 'SkinG2P.csv.gz',
         cancerBucket = 'CancerG2P.csv.gz',
+        cardiacBucket = 'CardiacG2P.csv.gz'
         evidenceFile = 'gene2phenotype.json.gz'
     log:
         'log/gene2Phenotype.log'
@@ -236,11 +238,13 @@ rule gene2Phenotype:
         cp {input.eyePanel} {output.eyeBucket}
         cp {input.skinPanel} {output.skinBucket}
         cp {input.cancerPanel} {output.cancerBucket}
+        cp {input.cardiacPanel} {output.cardiacBucket}
         python modules/Gene2Phenotype.py \
           --dd_panel {input.ddPanel} \
           --eye_panel {input.eyePanel} \
           --skin_panel {input.skinPanel} \
           --cancer_panel {input.cancerPanel} \
+          --cardiac_panel {input.cardiacPanel} \
           --output_file {output.evidenceFile} \
           --cache_dir {params.cacheDir} \
           --local

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -36,6 +36,7 @@ Gene2Phenotype:
   webSource_eye_panel: https://www.ebi.ac.uk/gene2phenotype/downloads/EyeG2P.csv.gz
   webSource_skin_panel: https://www.ebi.ac.uk/gene2phenotype/downloads/SkinG2P.csv.gz
   webSource_cancer_panel: https://www.ebi.ac.uk/gene2phenotype/downloads/CancerG2P.csv.gz
+  webSource_cardiac_panel: https://www.ebi.ac.uk/gene2phenotype/downloads/CardiacG2P.csv.gz
   inputBucket: gs://otar000-evidence_input/Gene2Phenotype/data_files
   outputBucket: gs://otar000-evidence_input/Gene2Phenotype/json
 intOGen:

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -32,10 +32,10 @@ GeneBurden:
   inputBucket: gs://otar000-evidence_input/GeneBurden/data_files
   outputBucket: gs://otar000-evidence_input/GeneBurden/json
 Gene2Phenotype:
-  webSource_dd_panel: http://ftp.ebi.ac.uk/pub/databases/gene2phenotype/DD/DDG2P_1_12_2021.csv.gz
-  webSource_eye_panel: http://ftp.ebi.ac.uk/pub/databases/gene2phenotype/Eye/EyeG2P_1_12_2021.csv.gz
-  webSource_skin_panel: http://ftp.ebi.ac.uk/pub/databases/gene2phenotype/Skin/SkinG2P_1_12_2021.csv.gz
-  webSource_cancer_panel: http://ftp.ebi.ac.uk/pub/databases/gene2phenotype/Cancer/CancerG2P_1_12_2021.csv.gz
+  webSource_dd_panel: https://www.ebi.ac.uk/gene2phenotype/downloads/DDG2P.csv.gz
+  webSource_eye_panel: https://www.ebi.ac.uk/gene2phenotype/downloads/EyeG2P.csv.gz
+  webSource_skin_panel: https://www.ebi.ac.uk/gene2phenotype/downloads/SkinG2P.csv.gz
+  webSource_cancer_panel: https://www.ebi.ac.uk/gene2phenotype/downloads/CancerG2P.csv.gz
   inputBucket: gs://otar000-evidence_input/Gene2Phenotype/data_files
   outputBucket: gs://otar000-evidence_input/Gene2Phenotype/json
 intOGen:

--- a/modules/Gene2Phenotype.py
+++ b/modules/Gene2Phenotype.py
@@ -62,7 +62,7 @@ def main(
     logging.info(f'{evidence_df.count()} evidence strings have been saved to {output_file}')
 
 def read_input_file(
-    dd_file: str, eye_file: str, skin_file: str, cancer_file: str
+    dd_file: str, eye_file: str, skin_file: str, cancer_file: str, cardiac_file: str
 ) -> DataFrame:
     '''
     Reads G2P's panel CSV files into a Spark DataFrame forcing the schema
@@ -90,7 +90,7 @@ def read_input_file(
 
     return (
         spark.read.csv(
-            [dd_file, eye_file, skin_file, cancer_file], schema=gene2phenotype_schema, enforceSchema=True, header=True
+            [dd_file, eye_file, skin_file, cancer_file, cardiac_file], schema=gene2phenotype_schema, enforceSchema=True, header=True
         )
     )
 
@@ -174,6 +174,9 @@ if __name__ == "__main__":
     parser.add_argument('-c', '--cancer_panel',
                         help='Cancer panel file downloaded from https://www.ebi.ac.uk/gene2phenotype/downloads',
                         required=True, type=str)
+    parser.add_argument('-cr', '--cardiac_panel',
+                        help='Cardiac panel file downloaded from https://www.ebi.ac.uk/gene2phenotype/downloads',
+                        required=True, type=str)
     parser.add_argument('-o', '--output_file', help='Absolute path of the gzipped, JSON evidence file.', required=True, type=str)
     parser.add_argument('-l', '--log_file', help='Filename to store the parser logs.', type=str)
     parser.add_argument('--cache_dir', required=False, help='Directory to store the OnToma cache files in.')
@@ -189,6 +192,7 @@ if __name__ == "__main__":
     eye_file = args.eye_panel
     skin_file = args.skin_panel
     cancer_file = args.cancer_panel
+    cardiac_file = args.cardiac_panel
     output_file = args.output_file
     log_file = args.log_file
     cache_dir = args.cache_dir
@@ -210,6 +214,7 @@ if __name__ == "__main__":
     logging.info(f'Eye panel file: {eye_file}')
     logging.info(f'Skin panel file: {skin_file}')
     logging.info(f'Cancer panel file: {cancer_file}')
+    logging.info(f'Cardiac panel file: {cardiac_file}')
 
     # Calling main:
-    main(dd_file, eye_file, skin_file, cancer_file, output_file, cache_dir, local)
+    main(dd_file, eye_file, skin_file, cancer_file, cardiac_file, output_file, cache_dir, local)

--- a/modules/Gene2Phenotype.py
+++ b/modules/Gene2Phenotype.py
@@ -25,7 +25,7 @@ G2P_mutationCsq2functionalCsq = {
 
 
 def main(
-    dd_file: str, eye_file: str, skin_file: str, cancer_file: str, output_file: str, cache_dir: str, local: bool = False
+    dd_file: str, eye_file: str, skin_file: str, cancer_file: str, cardiac_file: str, output_file: str, cache_dir: str, local: bool = False
 ) -> None:
 
     # Initialize spark session
@@ -49,7 +49,7 @@ def main(
 
     # Read and process G2P's tables into evidence strings
     gene2phenotype_df = read_input_file(
-        dd_file, eye_file, skin_file, cancer_file)
+        dd_file, eye_file, skin_file, cancer_file, cardiac_file)
     logging.info('Gene2Phenotype panels have been imported. Processing evidence strings.')
 
     evidence_df = process_gene2phenotype(gene2phenotype_df)


### PR DESCRIPTION
This PR covers the following updates around G2P datasource:
- [x] The problem is that the files for gene2phenotypes are not getting updates on the ftp.  Although we lose the data provenance (we don't know when the input files are generated on the g2p website), we at least can be sure these files are the most up to date. To resolve this, the config file is reverted.
- [x] New panel (cardiac) is available. Config file updated.
- [x] Processing of the new panel is included in the g2p module.
- [x] Snakemake is updated to include new panel.