### PR TITLE
Making EFO optional for evidence parsers

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -11,6 +11,10 @@ HTTP = HTTPRemoteProvider()
 timeStamp = datetime.now().strftime("%Y-%m-%d")  # YYYY-MM-DD.
 configfile: 'configuration.yaml'
 
+# Extracting EFO version from the configuration and export to the environment:
+EFO_version = config['global']['EFOVersion']
+os.environ["EFO_VERSION"] = EFO_version
+
 # The master list of all files with their local and remote filenames to avoid code duplication. Only the files specified
 # in this list will be generated and uploaded by the "all" and "local" rules.
 ALL_FILES = [

--- a/common/ontology.py
+++ b/common/ontology.py
@@ -39,7 +39,7 @@ def _ontoma_udf(row, ontoma_instance):
     return [m.id_ot_schema for m in mappings]
 
 
-def add_efo_mapping(evidence_strings, spark_instance, ontoma_cache_dir=None):
+def add_efo_mapping(evidence_strings, spark_instance, ontoma_cache_dir=None, efo_version='latest'):
     """Given evidence strings with diseaseFromSource and diseaseFromSourceId fields, try to populate EFO mapping
     field diseaseFromSourceMappedId. In case there are multiple matches, the evidence strings will be exploded
     accordingly.
@@ -50,7 +50,7 @@ def add_efo_mapping(evidence_strings, spark_instance, ontoma_cache_dir=None):
     disease_info_to_map = evidence_strings.select('diseaseFromSource', 'diseaseFromSourceId').distinct().toPandas()
 
     logging.info('Initialise OnToma instance')
-    ontoma_instance = OnToma(cache_dir=ontoma_cache_dir)
+    ontoma_instance = OnToma(cache_dir=ontoma_cache_dir, efo_release=efo_version)
 
     logging.info('Map disease information to EFO.')
     disease_info_to_map['diseaseFromSourceMappedId'] = disease_info_to_map.parallel_apply(

--- a/common/ontology.py
+++ b/common/ontology.py
@@ -59,7 +59,7 @@ def add_efo_mapping(evidence_strings, spark_instance, ontoma_cache_dir=None, efo
         else:
             efo_version = 'latest'
 
-    logging.info('Initialise OnToma instance. Using EFO version {efo_version}')
+    logging.info(f'Initialise OnToma instance. Using EFO version {efo_version}')
     ontoma_instance = OnToma(cache_dir=ontoma_cache_dir, efo_release=efo_version)
 
     logging.info('Map disease information to EFO.')

--- a/common/ontology.py
+++ b/common/ontology.py
@@ -57,6 +57,7 @@ def add_efo_mapping(evidence_strings, spark_instance, ontoma_cache_dir=None, efo
             efo_version = os.environ["EFO_VERSION"]
         # Set default version to latest.
         else:
+            logging.warning('No EFO version specified. Using latest version.')
             efo_version = 'latest'
 
     logging.info(f'Initialise OnToma instance. Using EFO version {efo_version}')

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -3,6 +3,7 @@ global:
   cacheDir: cache_dir
   # This is a directory prefix; individual schemas relative to it are specified by each rule.
   schema: https://raw.githubusercontent.com/opentargets/json_schema/2.2.4
+  EFOVersion: v3.40.0
 
 cancerBiomarkers:
   inputBucket: gs://otar000-evidence_input/CancerBiomarkers/data_files

--- a/modules/Gene2Phenotype.py
+++ b/modules/Gene2Phenotype.py
@@ -54,7 +54,7 @@ def main(
 
     evidence_df = process_gene2phenotype(gene2phenotype_df)
 
-    evidence_df = add_efo_mapping(evidence_strings=evidence_df, ontoma_cache_dir=cache_dir, spark_instance=spark, efo_version='v3.40.0')
+    evidence_df = add_efo_mapping(evidence_strings=evidence_df, ontoma_cache_dir=cache_dir, spark_instance=spark)
     logging.info('Disease mappings have been added.')
 
     # Saving data:
@@ -132,7 +132,7 @@ def process_gene2phenotype(gene2phenotype_df: DataFrame) -> DataFrame:
         .withColumn(
             'diseaseFromSourceId', 
             when(
-                col('disease ontology').isNotNull(), array(col('disease ontology'))                
+                col('disease ontology').isNotNull(), col('disease ontology')
             )
             .when(
                 (~col('disease mim').contains('No disease mim')) & (col('disease mim').isNotNull()), concat(lit('OMIM:'), col('disease mim'))

--- a/modules/Gene2Phenotype.py
+++ b/modules/Gene2Phenotype.py
@@ -126,19 +126,19 @@ def process_gene2phenotype(gene2phenotype_df: DataFrame) -> DataFrame:
                 col('allelic requirement').isNotNull(),
                 array(col('allelic requirement'))
             )
+        )
+
+        # Process diseaseFromSourceId:
+        .withColumn(
+            'diseaseFromSourceId', 
+            when(
+                col('disease ontology').isNotNull(), array(col('disease ontology'))                
+            )
             .when(
-                col('disease ontology').isNotNull(),
-                array(col('disease ontology'))                
+                (~col('disease mim').contains('No disease mim')) & (col('disease mim').isNotNull()), concat(lit('OMIM:'), col('diseaseFromSourceId'))
             )
             .otherwise(lit(None))
         )
-
-        # Process diseaseFromSource
-        .withColumn(
-            'diseaseFromSourceId',
-            when(~col('disease mim').contains('No disease mim'), col('disease mim'))
-        )
-        .withColumn('diseaseFromSourceId', concat(lit('OMIM:'), col('diseaseFromSourceId')))
 
         # Cleaning up disease names:
         .withColumn('diseaseFromSource', regexp_replace(col('diseaseFromSource'), r'.+-related ', ''))

--- a/modules/Gene2Phenotype.py
+++ b/modules/Gene2Phenotype.py
@@ -135,7 +135,7 @@ def process_gene2phenotype(gene2phenotype_df: DataFrame) -> DataFrame:
                 col('disease ontology').isNotNull(), array(col('disease ontology'))                
             )
             .when(
-                (~col('disease mim').contains('No disease mim')) & (col('disease mim').isNotNull()), concat(lit('OMIM:'), col('diseaseFromSourceId'))
+                (~col('disease mim').contains('No disease mim')) & (col('disease mim').isNotNull()), concat(lit('OMIM:'), col('disease mim'))
             )
             .otherwise(lit(None))
         )


### PR DESCRIPTION
This PR captures the effort to make EFO version optional in the evidence generation pipeline. 

* The EFO release is fixed in the config file for each release.
* This version will be read by snakemake
* An env variable is created by snakemake
* Env variable is read by the efo fucntion in commons to initialise Ontoma object

Also Gene2Phenotype update: 
- Fetching `diseaseFromSourceId` from `disease mim` column and `disease ontology` columns. 
- Parsing dyadic disease labels to improve disease mapping.