### PR TITLE
Add year of publication to the EPMC evidence

### DIFF
--- a/modules/EPMC.py
+++ b/modules/EPMC.py
@@ -101,6 +101,7 @@ def main(cooccurrences, outputFile):
                 )
             ).alias('textMiningSentences'),
             F.sum(F.col('evidence_score')).alias('resourceScore'),
+            F.min('year').alias('publicationYear'),
         )
         # Nullify pmcIds if empty array:
         .withColumn('pmcIds', F.when(F.size('pmcIds') != 0, F.col('pmcIds')))

--- a/modules/EPMC.py
+++ b/modules/EPMC.py
@@ -90,6 +90,7 @@ def main(cooccurrences, outputFile):
         .agg(
             F.collect_set(F.col('pmcid')).alias('pmcIds'),
             F.collect_set(F.col('pmid')).alias('literature'),
+            F.min('year').alias('publicationYear'),
             F.collect_set(
                 F.struct(
                     F.col('text'),
@@ -101,7 +102,6 @@ def main(cooccurrences, outputFile):
                 )
             ).alias('textMiningSentences'),
             F.sum(F.col('evidence_score')).alias('resourceScore'),
-            F.min('year').alias('publicationYear'),
         )
         # Nullify pmcIds if empty array:
         .withColumn('pmcIds', F.when(F.size('pmcIds') != 0, F.col('pmcIds')))
@@ -125,6 +125,7 @@ def main(cooccurrences, outputFile):
                 'literature',
                 'textMiningSentences',
                 'pmcIds',
+                'publicationYear',
             ]
         )
     )


### PR DESCRIPTION
Each EPMC evidence describes the t/d relationship in a given publication. We want to make the users able to filter the evidence by the publication year.

This PR processes the `year` field available in the cooccurrences to expose that in `publicationYear`. 
There are cases where more than one date is reported for the same publication. In this case we take the earlier year as the publication date (I checked some examples and this was accurate).