### PR TITLE
Updating pyspark version.

### DIFF
--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -29,6 +29,7 @@ google-resumable-media==2.3.3
 googleapis-common-protos==1.56.4
 httplib2==0.20.4
 idna==3.3
+importlib-resources==5.9.0
 Jinja2==3.1.2
 jsonschema==4.4.0
 jupyter-core==4.11.1
@@ -53,7 +54,7 @@ pyasn1-modules==0.2.8
 pyparsing==3.0.9
 pypeln==0.4.9
 pyrsistent==0.18.1
-pyspark==3.1.2
+pyspark==3.1.3
 python-dateutil==2.8.2
 pytz==2022.2.1
 PyYAML==6.0
@@ -77,3 +78,4 @@ uritemplate==4.1.1
 urllib3==1.26.11
 wrapt==1.14.1
 yte==1.5.1
+zipp==3.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pandarallel==1.5.2
 pandas==1.4.3
 pip==22.0.4
 pronto==2.5.0
-pyspark==3.1.2
+pyspark==3.1.3
 requests==2.27.1
 retry==0.9.2
 snakemake==7.3.8


### PR DESCRIPTION
Dependabot found a problematic pyspark version and recommended to change pyspark version to `3.1.3`. I didn't merge [dependabot's  PR](https://github.com/opentargets/evidence_datasource_parsers/pull/135), instead updated the requirements and requirements-frozen properly. 

Before merging, we have to make sure no pyspark functionality is broken. (the full pipeline needs to be re-run anyways.)