### PR TITLE
Il 2701

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -146,7 +146,7 @@ rule crispr:                  # Process cancer therapeutic targets using CRISPRâ
     input:
         evidenceFile = GS.remote(config['CRISPR']['inputAssociationsTable']),
         descriptionsFile = GS.remote(config['CRISPR']['inputDescriptionsTable']),
-        cellTypesFile = GS.remote(config['CRISPR']['inputCellTypesTable']")
+        cellTypesFile = GS.remote(config['CRISPR']['inputCellTypesTable'])
     params:
         schema = f"{config['global']['schema']}/opentargets.json"
     output:

--- a/Snakefile
+++ b/Snakefile
@@ -75,7 +75,7 @@ rule cancerBiomarkers:        # Process the Cancers Biomarkers database from Can
     input:
         biomarkers_table = GS.remote(config['cancerBiomarkers']['inputAssociationsTable']),
         source_table = GS.remote(config['cancerBiomarkers']['inputSourceTable']),
-        disease_table = GS.remote(config['cancerBiomarkers']['inputBucket']),
+        disease_table = GS.remote(config['cancerBiomarkers']['inputDiseaseTable']),
         drug_index = GS.remote(config['cancerBiomarkers']['drugIndex'])
     params:
         schema = f"{config['global']['schema']}/opentargets.json"

--- a/modules/GeneBurden.py
+++ b/modules/GeneBurden.py
@@ -67,7 +67,9 @@ def process_gene_burden_curation(curated_data: str) -> DataFrame:
             'allelicRequirements',
             F.when(F.col('allelicRequirements').isNotNull(), F.array(F.col('allelicRequirements'))),
         )
-        # 3. Add hardcoded values and drop URLs (will be handled by the FE) and HGNC symbols
+        # 3. Split the sex column to form an array
+        .withColumn('sex', F.split(F.col('sex'), ', '))
+        # 4. Add hardcoded values and drop URLs (will be handled by the FE) and HGNC symbols
         .withColumn('datasourceId', F.lit('gene_burden'))
         .withColumn('datatypeId', F.lit('genetic_association'))
         .drop('url', 'targetFromSource')
@@ -94,6 +96,7 @@ def read_gene_burden_curation(curated_data: str) -> DataFrame:
             T.StructField('ConfidenceIntervalLower', T.DoubleType(), True),
             T.StructField('ConfidenceIntervalUpper', T.DoubleType(), True),
             T.StructField('beta', T.DoubleType(), True),
+            T.StructField('sex', T.StringType(), True),
             T.StructField('ancestry', T.StringType(), True),
             T.StructField('ancestryId', T.StringType(), True),
             T.StructField('cohortId', T.StringType(), True),


### PR DESCRIPTION
This PR contains:
- the changes to adapt the parser to process the newly introduced `sex` column. Except for the 18 expected evidence, this field is null for the rest. This is an example evidence string:
```
-RECORD 0---------------------------------------------------------------------------------------------------------------------------
 allelicRequirements              | null
 ancestry                         | null
 ancestryId                       | null
 beta                             | 0.089
 betaConfidenceIntervalLower      | 0.066
 betaConfidenceIntervalUpper      | 0.11
 cohortId                         | UK Biobank, MDCS,  MCPS
 datasourceId                     | gene_burden
 datatypeId                       | genetic_association
 diseaseFromSource                | BMI-adjusted waist-hip ratio
 diseaseFromSourceId              | null
 diseaseFromSourceMappedId        | EFO_0007788
 literature                       | [35999217]
 oddsRatio                        | null
 oddsRatioConfidenceIntervalLower | null
 oddsRatioConfidenceIntervalUpper | null
 pValueExponent                   | -14
 pValueMantissa                   | 3.4
 projectId                        | null
 resourceScore                    | 3.4E-14
 sex                              | [women, men]
 statisticalMethod                | pLOF plus deleterious missense, AAF<1%
 statisticalMethodOverview        | Burden test carried out with pLOF and deleterious missense variants with a MAF smaller than 1%.
 studyCases                       | 83873
 studyCasesWithQualifyingVariants | 6277
 studyId                          | null
 studySampleSize                  | 618375
 targetFromSourceId               | ENSG00000079999
```
- Some fixes that were needed to adapt the parser

**Note that the base branch is the one containing the 2209 configuration**