### PR TITLE
Remove duplicated evidence from IMPC

### DIFF
--- a/modules/IMPC.py
+++ b/modules/IMPC.py
@@ -38,6 +38,12 @@ IMPC_SOLR_TABLES = {
 
 # List of fields on which to enforce uniqueness by only keeping the record with the highest score.
 UNIQUE_FIELDS = [
+    # Global
+    'targetId',
+    'targetFromSourceId',
+    'diseaseId',
+    'datasourceId',
+    # Specific for IMPC
     'diseaseFromSource',
     'biologicalModelAllelicComposition',
     'targetInModel',

--- a/modules/IMPC.py
+++ b/modules/IMPC.py
@@ -444,6 +444,11 @@ class IMPC:
         self.evidence = add_efo_mapping(evidence_strings=self.evidence, spark_instance=self.spark,
                                         ontoma_cache_dir=self.cache_dir)
 
+        # In case of multiple records with the same unique fields, keep only the one record with the highest score. This
+        # is done to avoid duplicates where multiple source ontology records map to the same EFO record with slightly
+        # different scores.
+        self.evidence = self.evidence.sort_values('resourceScore').groupby(UNIQUE_FIELDS).last()
+
         # Ensure stable column order.
         self.evidence = self.evidence.select(
             'biologicalModelAllelicComposition', 'biologicalModelGeneticBackground', 'biologicalModelId',

--- a/modules/IMPC.py
+++ b/modules/IMPC.py
@@ -38,16 +38,11 @@ IMPC_SOLR_TABLES = {
 
 # List of fields on which to enforce uniqueness by only keeping the record with the highest score.
 UNIQUE_FIELDS = [
-    # Global
-    'targetId',
-    'targetFromSourceId',
-    'diseaseId',
-    'datasourceId',
-    # Specific for IMPC
-    'diseaseFromSource',
-    'biologicalModelAllelicComposition',
-    'targetInModel',
-    'biologicalModelGeneticBackground',
+    'targetInModel',  # Mouse gene
+    'targetFromSourceId',  # Human gene
+    'biologicalModelAllelicComposition',  # Mouse model property
+    'biologicalModelGeneticBackground',  # Mouse model property
+    'diseaseFromSourceMappedId',  # The final (mapped) disease ID in EFO
 ]
 
 class ImpcSolrRetriever:

--- a/modules/IMPC.py
+++ b/modules/IMPC.py
@@ -35,6 +35,14 @@ IMPC_SOLR_TABLES = {
 }
 
 
+# List of fields on which to enforce uniqueness by only keeping the record with the highest score.
+UNIQUE_FIELDS = [
+    'diseaseFromSource',
+    'biologicalModelAllelicComposition',
+    'targetInModel',
+    'biologicalModelGeneticBackground',
+]
+
 class ImpcSolrRetriever:
     """Retrieve data from the IMPC SOLR API and save the CSV files to the specified location."""
 

--- a/modules/IMPC.py
+++ b/modules/IMPC.py
@@ -38,11 +38,15 @@ IMPC_SOLR_TABLES = {
 
 # List of fields on which to enforce uniqueness by only keeping the record with the highest score.
 UNIQUE_FIELDS = [
-    'targetInModel',  # Mouse gene
-    'targetFromSourceId',  # Human gene
-    'biologicalModelAllelicComposition',  # Mouse model property
-    'biologicalModelGeneticBackground',  # Mouse model property
-    'diseaseFromSourceMappedId',  # The final (mapped) disease ID in EFO
+    # Specific to IMPC.
+    'diseaseFromSource',  # Original disease name.
+    'targetInModel',  # Mouse gene name.
+    'biologicalModelAllelicComposition',  # Mouse model property.
+    'biologicalModelGeneticBackground',  # Mouse model property.
+
+    # General.
+    'diseaseFromSourceMappedId',  # EFO mapped disease ID.
+    'targetFromSourceId',  # Ensembl mapped human gene ID.
 ]
 
 class ImpcSolrRetriever:

--- a/modules/IMPC.py
+++ b/modules/IMPC.py
@@ -448,7 +448,7 @@ class IMPC:
         # In case of multiple records with the same unique fields, keep only the one record with the highest score. This
         # is done to avoid duplicates where multiple source ontology records map to the same EFO record with slightly
         # different scores.
-        w = Window.partitionBy([UNIQUE_FIELDS]).orderBy('resourceScore').desc()
+        w = Window.partitionBy([pf.col(c) for c in UNIQUE_FIELDS]).orderBy('resourceScore').desc()
         self.evidence = (
             self.evidence
             .withColumn('row', pf.row_number().over(w))

--- a/modules/IMPC.py
+++ b/modules/IMPC.py
@@ -448,7 +448,7 @@ class IMPC:
         # In case of multiple records with the same unique fields, keep only the one record with the highest score. This
         # is done to avoid duplicates where multiple source ontology records map to the same EFO record with slightly
         # different scores.
-        w = Window.partitionBy([pf.col(c) for c in UNIQUE_FIELDS]).orderBy('resourceScore').desc()
+        w = Window.partitionBy([pf.col(c) for c in UNIQUE_FIELDS]).orderBy(pf.col('resourceScore').desc())
         self.evidence = (
             self.evidence
             .withColumn('row', pf.row_number().over(w))


### PR DESCRIPTION
Closes https://github.com/opentargets/issues/issues/1805.

The following fields are now used to enforce uniqueness:
```python
    # Specific to IMPC.
    'diseaseFromSource',  # Original disease name.
    'targetInModel',  # Mouse gene name.
    'biologicalModelAllelicComposition',  # Mouse model property.
    'biologicalModelGeneticBackground',  # Mouse model property.

    # General.
    'diseaseFromSourceMappedId',  # EFO mapped disease ID.
    'targetFromSourceId',  # Ensembl mapped human gene ID.
```

Evidence count decrease is now adequate, in its expected order of magnitude, to our expectations.