### PR TITLE
feat: updating config for the 23.02 release

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1,8 +1,8 @@
 global:
   logDir: gs://otar000-evidence_input/parser_logs
   cacheDir: cache_dir
-  schema: https://raw.githubusercontent.com/opentargets/json_schema/2.2.9
-  EFOVersion: v3.47.0
+  schema: https://rawi.githubusercontent.com/opentargets/json_schema/2.2.10
+  EFOVersion: v3.50.0
 
 cancerBiomarkers:
   inputAssociationsTable: gs://otar000-evidence_input/CancerBiomarkers/data_files/cancerbiomarkers-2018-05-01.tsv
@@ -26,7 +26,7 @@ CRISPR:
 GeneBurden:
   azPhewasBinary: gs://otar000-evidence_input/GeneBurden/data_files/azphewas-com-450k-phewas-binary
   azPhewasQuantitative: gs://otar000-evidence_input/GeneBurden/data_files/azphewas-com-450k-phewas-quantitative
-  curation: https://raw.githubusercontent.com/opentargets/curation/22.11.2/gene_burden/curated_evidence.tsv
+  curation: https://raw.githubusercontent.com/opentargets/curation/23.02/gene_burden/curated_evidence.tsv
   genebass: gs://otar000-evidence_input/GeneBurden/data_files/genebass_entries
   outputBucket: gs://otar000-evidence_input/GeneBurden/json
 Gene2Phenotype:
@@ -67,8 +67,8 @@ SysBio:
 TEP:
   outputBucket: gs://otar001-core/TEPs
 TargetSafety:
-  adverseEvents: https://raw.githubusercontent.com/opentargets/curation/22.11.2/target_safety/adverse_effects.tsv
-  safetyRisk: https://raw.githubusercontent.com/opentargets/curation/22.11.2/target_safety/safety_risks.tsv
+  adverseEvents: https://raw.githubusercontent.com/opentargets/curation/23.02/target_safety/adverse_effects.tsv
+  safetyRisk: https://raw.githubusercontent.com/opentargets/curation/23.02/target_safety/safety_risks.tsv
   toxcast: gs://otar001-core/TargetSafety/data_files/toxcast/ToxCast_2021-08-17.tsv
   aopwiki: gs://otar001-core/TargetSafety/data_files/aopwiki/aopwiki-2023-01-20.json
   outputBucket: gs://otar001-core/TargetSafety/json

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1,7 +1,7 @@
 global:
   logDir: gs://otar000-evidence_input/parser_logs
   cacheDir: cache_dir
-  schema: https://rawi.githubusercontent.com/opentargets/json_schema/2.2.10
+  schema: https://raw.githubusercontent.com/opentargets/json_schema/2.2.10
   EFOVersion: v3.50.0
 
 cancerBiomarkers:


### PR DESCRIPTION
**Practically updating a few things:**
- [x] EFO version ([v.3.50.0](https://github.com/EBISPOT/efo/releases/tag/v3.50.0))
- [x] JSON schema version ([2.2.10](https://github.com/opentargets/json_schema/releases/tag/2.2.10))
- [x] Curation version for a few lines ([23.02](https://github.com/opentargets/curation/releases/tag/23.02)) (this could be refactored a bit to make sure we only need to set it once)

No other updates were made. This time the dependency issues were not addressed. Scoped under [#2834](https://github.com/opentargets/issues/issues/2834)