### PR TITLE
Ds 2911 ppp snakemake

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -430,3 +430,25 @@ rule ot_crispr:               # Generating evidence for OTAR CRISPR screens
         opentargets_validator --schema {params.schema} {output}
         """
 
+rule validation_lab:               # Generating evidence for OTAR CRISPR screens
+    params:
+        data_folder = config['ValidationLab']['data_directory'],
+        config = config['ValidationLab']['config'],
+        schema = f"{config['global']['schema']}/opentargets.json"
+    input:
+        cell_passport_table = HTTP.remote(config['ValidationLab']['cell_passport_file'], keep_local=True),
+    output:
+        'validation_lab.json.gz'
+    log:
+        'log/validation_lab.log'
+    shell:
+        """
+        exec &> {log}
+        python partner_preview_scripts/ValidationLab.py \
+            --parameter_file {params.config} \
+            --data_folder {params.data_folder} \
+            --cell_passport_file {input.cell_passport_table} \
+            --output_file {output}
+        opentargets_validator --schema {params.schema} {output}
+        """
+

--- a/Snakefile
+++ b/Snakefile
@@ -417,8 +417,8 @@ rule targetSafety:            # Process data from different sources that describ
             --output {output}
         opentargets_validator --schema {params.schema} {output}
         """
-# --- Evidence generation for PPP --- #
-rule ot_crispr:               # Generating evidence for OTAR CRISPR screens
+
+rule ot_crispr:               # Generating PPP evidence for OTAR CRISPR screens
     params:
         data_folder = config['OT_CRISPR']['data_directory'],
         study_table = config['OT_CRISPR']['config'],
@@ -436,8 +436,8 @@ rule ot_crispr:               # Generating evidence for OTAR CRISPR screens
             --output {output}
         # opentargets_validator --schema {params.schema} {output}
         """
-# --- Evidence generation for PPP --- #
-rule encore:               # Generating evidence for OTAR CRISPR screens
+
+rule encore:               # Generating PPP evidence for ENCORE
     params:
         data_folder = config['Encore']['data_directory'],
         config = config['Encore']['config'],
@@ -459,7 +459,7 @@ rule encore:               # Generating evidence for OTAR CRISPR screens
         # opentargets_validator --schema {params.schema} {output}
         """
 
-rule validation_lab:               # Generating evidence for OTAR CRISPR screens
+rule validation_lab:               # Generating PPP evidence for Validation Lab
     params:
         data_folder = config['ValidationLab']['data_directory'],
         config = config['ValidationLab']['config'],
@@ -480,8 +480,8 @@ rule validation_lab:               # Generating evidence for OTAR CRISPR screens
             --output_file {output}
         opentargets_validator --schema {params.schema} {output}
         """
-# --- Moving local PPP files to remote --- #
-rule PPP:                          # Moving PPP evidence to destination bucket.
+
+rule PPP:                          # Moving local PPP evidence to the destination bucket.
     input:
         [source[0] for source in PPP_sources]
     output:

--- a/Snakefile
+++ b/Snakefile
@@ -84,7 +84,7 @@ rule cancerBiomarkers:        # Process the Cancers Biomarkers database from Can
         disease_table = GS.remote(config['cancerBiomarkers']['inputDiseaseTable']),
         drug_index = GS.remote(config['cancerBiomarkers']['drugIndex'])
     params:
-        schema = f"{config['global']['schema']}/opentargets.json"
+        schema = f"{config['global']['schema']}/schemas/disease_target_evidence.json"
     output:
         'cancer_biomarkers.json.gz'
     log:
@@ -108,7 +108,7 @@ rule chembl:                  # Add the category of why a clinical trial has sto
         evidenceFile = GS.remote(config['ChEMBL']['evidence']),
         stopReasonCategories = GS.remote(config['ChEMBL']['stopReasonCategories'])
     params:
-        schema = f"{config['global']['schema']}/opentargets.json"
+        schema = f"{config['global']['schema']}/schemas/disease_target_evidence.json"
     output:
         evidenceFile = 'chembl.json.gz'
     log:
@@ -127,7 +127,7 @@ rule clingen:                 # Process the Gene Validity Curations table from C
     params:
         summaryTableWeb = config['ClinGen']['webSource'],
         cacheDir = config['global']['cacheDir'],
-        schema = f"{config['global']['schema']}/opentargets.json"
+        schema = f"{config['global']['schema']}/schemas/disease_target_evidence.json"
     output:
         evidenceFile = 'clingen.json.gz',
         summaryTable = 'clingen-Gene-Disease-Summary.csv'
@@ -154,7 +154,7 @@ rule crispr:                  # Process cancer therapeutic targets using CRISPRâ
         descriptionsFile = GS.remote(config['CRISPR']['inputDescriptionsTable']),
         cellTypesFile = GS.remote(config['CRISPR']['inputCellTypesTable'])
     params:
-        schema = f"{config['global']['schema']}/opentargets.json"
+        schema = f"{config['global']['schema']}/schemas/disease_target_evidence.json"
     output:
         evidenceFile = 'crispr.json.gz'
     log:
@@ -179,7 +179,7 @@ rule geneBurden:              # Processes gene burden data from various burden a
     output:
         evidenceFile = "gene_burden.json.gz"
     params:
-        schema = f"{config['global']['schema']}/opentargets.json"
+        schema = f"{config['global']['schema']}/schemas/disease_target_evidence.json"
     log:
         'log/gene_burden.log'
     shell:
@@ -203,7 +203,7 @@ rule gene2Phenotype:          # Processes four gene panels from Gene2Phenotype
         cardiacPanel = HTTP.remote(config['Gene2Phenotype']['webSource_cardiac_panel'])
     params:
         cacheDir = config['global']['cacheDir'],
-        schema = f"{config['global']['schema']}/opentargets.json"
+        schema = f"{config['global']['schema']}/schemas/disease_target_evidence.json"
     output:
         ddBucket = 'DDG2P.csv.gz',
         eyeBucket = 'EyeG2P.csv.gz',
@@ -240,7 +240,7 @@ rule intogen:                 # Process cohorts and driver genes data from intOG
         inputCohorts = GS.remote(config['intOGen']['inputCohortsTable']),
         diseaseMapping = config['intOGen']['diseaseMapping']
     params:
-        schema = f"{config['global']['schema']}/opentargets.json"
+        schema = f"{config['global']['schema']}/schemas/disease_target_evidence.json"
     output:
         evidenceFile = 'intogen.json.gz'
     log:
@@ -261,7 +261,7 @@ rule orphanet:                # Process disease/target evidence from Orphanet.
         HTTP.remote(config['Orphanet']['webSource'])
     params:
         cacheDir = config['global']['cacheDir'],
-        schema = f"{config['global']['schema']}/opentargets.json"
+        schema = f"{config['global']['schema']}/schemas/disease_target_evidence.json"
     output:
         'orphanet.json.gz'
     log:
@@ -281,7 +281,7 @@ rule panelApp:                # Process gene panels data curated by Genomics Eng
         inputFile = GS.remote(config['PanelApp']['inputAssociationsTable'])
     params:
         cacheDir = config['global']['cacheDir'],
-        schema = f"{config['global']['schema']}/opentargets.json"
+        schema = f"{config['global']['schema']}/schemas/disease_target_evidence.json"
     output:
         evidenceFile = 'genomics_england.json.gz'
     log:
@@ -299,7 +299,7 @@ rule panelApp:                # Process gene panels data curated by Genomics Eng
 rule impc:                    # Process target-disease evidence and mouseModels dataset by querying the IMPC SOLR API.
     params:
         cacheDir = config['global']['cacheDir'],
-        schema = f"{config['global']['schema']}/opentargets.json"
+        schema = f"{config['global']['schema']}/schemas/disease_target_evidence.json"
     output:
         evidenceFile='impc.json.gz',
         mousePhenotypes='mouse_phenotypes.json.gz'
@@ -322,7 +322,7 @@ rule progeny:                 # Process gene expression data from TCGA derived f
         diseaseMapping = config['PROGENy']['inputDiseaseMapping'],
         pathwayMapping = config['PROGENy']['inputPathwayMapping']
     params:
-        schema = f"{config['global']['schema']}/opentargets.json"
+        schema = f"{config['global']['schema']}/schemas/disease_target_evidence.json"
     output:
         evidenceFile = 'progeny.json.gz'
     log:
@@ -343,7 +343,7 @@ rule slapenrich:              # Process cancer-target evidence strings derived f
         inputFile = GS.remote(config['SLAPEnrich']['inputAssociationsTable']),
         diseaseMapping = config['SLAPEnrich']['inputDiseaseMapping']
     params:
-        schema = f"{config['global']['schema']}/opentargets.json"
+        schema = f"{config['global']['schema']}/schemas/disease_target_evidence.json"
     output:
         evidenceFile = 'slapenrich.json.gz'
     log:
@@ -363,7 +363,7 @@ rule sysbio:                  # Process key driver genes for specific diseases t
         evidenceFile = GS.remote(config['SysBio']['inputAssociationsTable']),
         studyFile = GS.remote(config['SysBio']['inputStudyTable'])
     params:
-        schema = f"{config['global']['schema']}/opentargets.json"
+        schema = f"{config['global']['schema']}/schemas/disease_target_evidence.json"
     output:
         evidenceFile = 'sysbio.json.gz'
     log:
@@ -381,7 +381,7 @@ rule sysbio:                  # Process key driver genes for specific diseases t
 # --- Target annotation data sources parsers --- #
 rule targetEnablingPackages:  # Fetching Target Enabling Packages (TEP) data from Structural Genomics Consortium
     params:
-        schema = f"{config['global']['schema']}/opentargets_tep.json"
+        schema = f"{config['global']['schema']}/schemas/TEP.json"
     output:
         'tep.json.gz'
     log:
@@ -401,7 +401,7 @@ rule targetSafety:            # Process data from different sources that describ
     params:
         ae = config['TargetSafety']['adverseEvents'],
         sr = config['TargetSafety']['safetyRisk'],
-        schema = f"{config['global']['schema']}/opentargets_target_safety.json"
+        schema = f"{config['global']['schema']}/schemas/opentargets_target_safety.json"
     output:
         'safetyLiabilities.json.gz'
     log:
@@ -422,7 +422,7 @@ rule ot_crispr:               # Generating PPP evidence for OTAR CRISPR screens
     params:
         data_folder = config['OT_CRISPR']['data_directory'],
         study_table = config['OT_CRISPR']['config'],
-        schema = f"{config['global']['schema']}/opentargets.json"
+        schema = f"{config['global']['schema']}/schemas/disease_target_evidence.json"
     output:
         'ot_crispr.json.gz'
     log:
@@ -434,14 +434,14 @@ rule ot_crispr:               # Generating PPP evidence for OTAR CRISPR screens
             --study_table {params.study_table} \
             --data_folder {params.data_folder} \
             --output {output}
-        # opentargets_validator --schema {params.schema} {output}
+        opentargets_validator --schema {params.schema} {output}
         """
 
 rule encore:               # Generating PPP evidence for ENCORE
     params:
         data_folder = config['Encore']['data_directory'],
         config = config['Encore']['config'],
-        schema = f"{config['global']['schema']}/opentargets.json"
+        schema = f"{config['global']['schema']}/schemas/disease_target_evidence.json"
     output:
         'encore.json.gz'
     input:
@@ -456,14 +456,14 @@ rule encore:               # Generating PPP evidence for ENCORE
             --parameter_file {params.config} \
             --data_folder {params.data_folder} \
             --cell_passport_file {input.cell_passport_table}
-        # opentargets_validator --schema {params.schema} {output}
+        opentargets_validator --schema {params.schema} {output}
         """
 
 rule validation_lab:               # Generating PPP evidence for Validation Lab
     params:
         data_folder = config['ValidationLab']['data_directory'],
         config = config['ValidationLab']['config'],
-        schema = f"{config['global']['schema']}/opentargets.json"
+        schema = f"{config['global']['schema']}/schemas/disease_target_evidence.json"
     input:
         cell_passport_table = HTTP.remote(config['global']['cell_passport_file'], keep_local=True),
     output:

--- a/Snakefile
+++ b/Snakefile
@@ -410,3 +410,23 @@ rule targetSafety:            # Process data from different sources that describ
             --output {output}
         opentargets_validator --schema {params.schema} {output}
         """
+# --- Evidence generation for PPP --- #
+rule ot_crispr:               # Generating evidence for OTAR CRISPR screens
+    params:
+        data_folder = config['OT_CRISPR']['data_directory'],
+        study_table = config['OT_CRISPR']['config'],
+        schema = f"{config['global']['schema']}/opentargets.json"
+    output:
+        'ot_crispr.json.gz'
+    log:
+        'log/ot_crispr.log'
+    shell:
+        """
+        exec &> {log}
+        python partner_preview_scripts/ot_crispr.py \
+            --study_table {params.study_table} \
+            --data_folder {params.data_folder} \
+            --output {output}
+        opentargets_validator --schema {params.schema} {output}
+        """
+

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -74,13 +74,13 @@ TargetSafety:
   outputBucket: gs://otar001-core/TargetSafety/json
 OT_CRISPR:
   data_directory: gs://otar013-ppp/ot_crispr/input_data
-  config: gs://otar013-ppp/PPP-evidencie-configuration/ot_crispr_config.json
+  config: gs://otar013-ppp/PPP-evidence-configuration/ot_crispr_config.json
   outputBucket: gs://otar013-ppp/ot_crispr
 ValidationLab:
   data_directory: gs://otar013-ppp/validation_lab/input_data/2022.05
-  config: gs://otar013-ppp/PPP-evidencie-configuration/ValidationLab_config.json
+  config: gs://otar013-ppp/PPP-evidence-configuration/ValidationLab_config.json
   outputBucket: gs://otar013-ppp/validation_lab
 Encore:
   data_directory: gs://otar013-ppp/encore/input
-  config: gs://otar013-ppp/PPP-evidencie-configuration/encore_config.json
+  config: gs://otar013-ppp/PPP-evidence-configuration/encore_config.json
   outputBucket: gs://otar013-ppp/encore

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -73,14 +73,14 @@ TargetSafety:
   aopwiki: gs://otar001-core/TargetSafety/data_files/aopwiki/aopwiki-2023-01-20.json
   outputBucket: gs://otar001-core/TargetSafety/json
 OT_CRISPR:
-  data_directory: gs://otar013-ppp/ot_crispr/input_data/
-  config: /Users/dsuveges/repositories/PPP-evidencie-configuration/ot_crispr_config.json
-  outputBucket: gs://otar013-ppp/ot_crispr/
+  data_directory: gs://otar013-ppp/ot_crispr/input_data
+  config: gs://otar013-ppp/PPP-evidencie-configuration/ot_crispr_config.json
+  outputBucket: gs://otar013-ppp/ot_crispr
 ValidationLab:
   data_directory: /Users/dsuveges/project_data/validation_lab/2022.05/PPP_OTVL_May2022
-  config: /Users/dsuveges/repositories/PPP-evidencie-configuration/ValidationLab_config.json
+  config: gs://otar013-ppp/PPP-evidencie-configuration/ValidationLab_config.json
   outputBucket: gs://otar013-ppp/validation_lab
 Encore:
   data_directory: /Users/dsuveges/project_data/encore/2022.07/PPP_RELEASE
-  config: /Users/dsuveges/repositories/PPP-evidencie-configuration/encore_config.json
+  config: gs://otar013-ppp/PPP-evidencie-configuration/encore_config.json
   outputBucket: gs://otar013-ppp/encore

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -3,7 +3,7 @@ global:
   cacheDir: cache_dir
   schema: https://raw.githubusercontent.com/opentargets/json_schema/2.2.10
   EFOVersion: v3.50.0
-
+  cell_passport_file: https://cog.sanger.ac.uk/cmp/download/model_list_latest.csv.gz
 cancerBiomarkers:
   inputAssociationsTable: gs://otar000-evidence_input/CancerBiomarkers/data_files/cancerbiomarkers-2018-05-01.tsv
   inputSourceTable: gs://otar000-evidence_input/CancerBiomarkers/data_files/cancer_biomarker_source.jsonl
@@ -75,7 +75,12 @@ TargetSafety:
 OT_CRISPR:
   data_directory: gs://otar013-ppp/ot_crispr/input_data/
   config: /Users/dsuveges/repositories/PPP-evidencie-configuration/ot_crispr_config.json
+  outputBucket: gs://otar013-ppp/ot_crispr/
 ValidationLab:
   data_directory: /Users/dsuveges/project_data/validation_lab/2022.05/PPP_OTVL_May2022
   config: /Users/dsuveges/repositories/PPP-evidencie-configuration/ValidationLab_config.json
-  cell_passport_file: https://cog.sanger.ac.uk/cmp/download/model_list_latest.csv.gz
+  outputBucket: gs://otar013-ppp/validation_lab
+Encore:
+  data_directory: /Users/dsuveges/project_data/encore/2022.07/PPP_RELEASE
+  config: /Users/dsuveges/repositories/PPP-evidencie-configuration/encore_config.json
+  outputBucket: gs://otar013-ppp/encore

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1,7 +1,7 @@
 global:
   logDir: gs://otar000-evidence_input/parser_logs
   cacheDir: cache_dir
-  schema: https://raw.githubusercontent.com/opentargets/json_schema/2.2.10
+  schema: https://raw.githubusercontent.com/opentargets/json_schema/2.3.1
   EFOVersion: v3.50.0
   cell_passport_file: https://cog.sanger.ac.uk/cmp/download/model_list_latest.csv.gz
 cancerBiomarkers:
@@ -77,10 +77,10 @@ OT_CRISPR:
   config: gs://otar013-ppp/PPP-evidencie-configuration/ot_crispr_config.json
   outputBucket: gs://otar013-ppp/ot_crispr
 ValidationLab:
-  data_directory: /Users/dsuveges/project_data/validation_lab/2022.05/PPP_OTVL_May2022
+  data_directory: gs://otar013-ppp/validation_lab/input_data/2022.05
   config: gs://otar013-ppp/PPP-evidencie-configuration/ValidationLab_config.json
   outputBucket: gs://otar013-ppp/validation_lab
 Encore:
-  data_directory: /Users/dsuveges/project_data/encore/2022.07/PPP_RELEASE
+  data_directory: gs://otar013-ppp/encore/input
   config: gs://otar013-ppp/PPP-evidencie-configuration/encore_config.json
   outputBucket: gs://otar013-ppp/encore

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -75,3 +75,7 @@ TargetSafety:
 OT_CRISPR:
   data_directory: gs://otar013-ppp/ot_crispr/input_data/
   config: /Users/dsuveges/repositories/PPP-evidencie-configuration/ot_crispr_config.json
+ValidationLab:
+  data_directory: /Users/dsuveges/project_data/validation_lab/2022.05/PPP_OTVL_May2022
+  config: /Users/dsuveges/repositories/PPP-evidencie-configuration/ValidationLab_config.json
+  cell_passport_file: https://cog.sanger.ac.uk/cmp/download/model_list_latest.csv.gz

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -72,3 +72,6 @@ TargetSafety:
   toxcast: gs://otar001-core/TargetSafety/data_files/toxcast/ToxCast_2021-08-17.tsv
   aopwiki: gs://otar001-core/TargetSafety/data_files/aopwiki/aopwiki-2023-01-20.json
   outputBucket: gs://otar001-core/TargetSafety/json
+OT_CRISPR:
+  data_directory: gs://otar013-ppp/ot_crispr/input_data/
+  config: /Users/dsuveges/repositories/PPP-evidencie-configuration/ot_crispr_config.json

--- a/partner_preview_scripts/ValidationLab.py
+++ b/partner_preview_scripts/ValidationLab.py
@@ -11,7 +11,6 @@
 """
 
 import argparse
-import json
 import logging
 import sys
 from functools import reduce
@@ -21,7 +20,11 @@ import pyspark.sql.functions as f
 import pyspark.sql.types as t
 from pyspark.sql.dataframe import DataFrame
 
-from common.evidence import write_evidence_strings, initialize_sparksession
+from common.evidence import (
+    write_evidence_strings,
+    initialize_sparksession,
+    read_ppp_config,
+)
 
 
 # Datasource-wide constants:
@@ -207,20 +210,6 @@ def get_biomarker(column_name, biomarker):
     else:
         logging.warning(f"Could not find direct mapping for {column_name}: {biomarker}")
         return None
-
-
-def parse_experimental_parameters(parmeterFile: str) -> dict:
-    """
-    Parse experimental parameters from a file.
-
-    Args:
-        parmeter_file: Path to a file containing experimental parameters.
-
-    Returns:
-        A dictionary of experimental parameters.
-    """
-    with open(parmeterFile, "r") as f:
-        return json.load(f)
 
 
 def get_cell_passport_data(spark: SparkSession, cell_passport_file: str) -> DataFrame:
@@ -414,7 +403,7 @@ def main(
     spark = initialize_sparksession()
 
     # Parse experimental parameters:
-    parameters = parse_experimental_parameters(config_file)
+    parameters = read_ppp_config(config_file)
 
     # Opening and parsing the cell passport data from Sanger:
     cell_passport_df = get_cell_passport_data(spark, cell_passport_file)

--- a/partner_preview_scripts/encore_parser.py
+++ b/partner_preview_scripts/encore_parser.py
@@ -2,7 +2,6 @@
 """Parser for data submitted by the Encore team."""
 
 import argparse
-import json
 import logging
 import os
 import sys
@@ -20,6 +19,7 @@ from common.evidence import (
     initialize_sparksession,
     write_evidence_strings,
     GenerateDiseaseCellLines,
+    read_ppp_config,
 )
 
 
@@ -600,11 +600,7 @@ if __name__ == "__main__":
         raise ValueError(f"Data folder {args.data_folder} does not exist.")
 
     # Reading parameter json:
-    try:
-        with open(args.parameter_file, "r") as parameter_file:
-            parameters = json.load(parameter_file)
-    except Exception as e:
-        raise e(f"Could not read parameter file. {args.parameter_file}")
+    parameters = read_ppp_config(args.parameter_file)
 
     # Updating parameters:
     parameters["sharedMetadata"]["data_folder"] = args.data_folder

--- a/partner_preview_scripts/ot_crispr.py
+++ b/partner_preview_scripts/ot_crispr.py
@@ -16,8 +16,6 @@ import logging
 import sys
 import pandas as pd
 
-from common.evidence import read_ppp_config
-
 # The statisticalTestTail is inferred by the column name which is being filtered on:
 FILTER_COLUMN_MAP = {
     "pos|fdr": "upper tail",

--- a/partner_preview_scripts/ot_crispr.py
+++ b/partner_preview_scripts/ot_crispr.py
@@ -14,8 +14,9 @@ import gzip
 import json
 import logging
 import sys
-
 import pandas as pd
+
+from common.evidence import read_ppp_config
 
 # The statisticalTestTail is inferred by the column name which is being filtered on:
 FILTER_COLUMN_MAP = {
@@ -155,6 +156,7 @@ class OTAR_CRISPR_study_parser(object):
         threshold = float(row["threshold"])
         studyId = row["studyId"]
         controlDataFile = row["ControlDataset"]
+        print(f"Data file: {datafile}")
         # Read data, filter and rename columns:
         mageck_df = (
             pd.read_csv(datafile, sep="\t")

--- a/partner_preview_scripts/ot_crispr.py
+++ b/partner_preview_scripts/ot_crispr.py
@@ -135,7 +135,7 @@ class OTAR_CRISPR_study_parser(object):
     @staticmethod
     def cleaning_gene_id(gene_id: str) -> str:
         """Expandable set of string processing steps to clean gene identifiers.
-        
+
         Examples:
             >>> cleaning_gene_id("ENSG00000187123_LYPD6")
             >>> "ENSG00000187123"
@@ -155,7 +155,6 @@ class OTAR_CRISPR_study_parser(object):
         threshold = float(row["threshold"])
         studyId = row["studyId"]
         controlDataFile = row["ControlDataset"]
-
         # Read data, filter and rename columns:
         mageck_df = (
             pd.read_csv(datafile, sep="\t")


### PR DESCRIPTION
Although the snakemake pipeline might not last too long, it makes sense to write up the rules for generating evidence files for PPP. 
- If the snakemake was at some point replaced by other methods, if the rules are available it would easier to make the transition.
- So far there was no documentation on this process. 

**Caveats**:

- The encore datasets are not yet moved to google storage.
- The management of the configuration is not yet fully solved: files are stored in a versioned, private repo, but hard to refer 
and access in a pipeline.
- The standard service account does not yet have write permission on the `gs://OTAR013-PPP/` bucket.  

Issue: [#2911](https://github.com/opentargets/issues/issues/2911)