### PR TITLE
Changes for Platform release 23.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,18 @@ The schema version which the evidence is validated against can be tweaked in [`c
 ```bash
 # Set parameters.
 export INSTANCE_NAME=evidence-generation
+export INSTANCE_PROJECT=open-targets-eu-dev
 export INSTANCE_ZONE=europe-west1-d
 # Create the instance and SSH.
 gcloud compute instances create \
   ${INSTANCE_NAME} \
-  --project=open-targets-eu-dev \
+  --project=${INSTANCE_PROJECT} \
   --zone=${INSTANCE_ZONE} \
   --machine-type=n1-highmem-32 \
   --service-account=426265110888-compute@developer.gserviceaccount.com \
   --scopes=https://www.googleapis.com/auth/cloud-platform \
   --create-disk=auto-delete=yes,boot=yes,device-name=${INSTANCE_NAME},image=projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20210927,mode=rw,size=2000,type=projects/open-targets-eu-dev/zones/europe-west1-d/diskTypes/pd-balanced
-gcloud compute ssh --zone ${INSTANCE_ZONE} ${INSTANCE_NAME}
+gcloud compute ssh --project ${INSTANCE_PROJECT} --zone ${INSTANCE_ZONE} ${INSTANCE_NAME}
 
 screen
 

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1,10 +1,10 @@
 global:
   logDir: gs://otar000-evidence_input/parser_logs
   cacheDir: cache_dir
-  schema: https://raw.githubusercontent.com/opentargets/json_schema/master
-  EFOVersion: v3.57.0
+  schema: https://raw.githubusercontent.com/opentargets/json_schema/2.5.0
+  EFOVersion: v3.58.0
   cell_passport_file: https://cog.sanger.ac.uk/cmp/download/model_list_latest.csv.gz
-  curation_repo: https://raw.githubusercontent.com/opentargets/curation/master
+  curation_repo: https://raw.githubusercontent.com/opentargets/curation/23.12
 baselineExpression:
   gtexSourceDataPath: https://storage.googleapis.com/gtex_analysis_v8/rna_seq_data/GTEx_Analysis_2017-06-05_v8_RNASeQCv1.1.9_gene_median_tpm.gct.gz
   tissueNameToUberonMappingPath: mappings/biosystem/gtex_v8_tissues.tsv


### PR DESCRIPTION
Microscopic changes for the Platform release, namely pinning the versions and making a tiny adjustment to the instance set up instructions.

Note that EFO version is pinned to 3.58.0, the one circulated in the release announcement email.