### PR TITLE
feat: import_trait_mappings reads disease curation from configIl 2907

### DIFF
--- a/modules/GenebassGeneBurden.py
+++ b/modules/GenebassGeneBurden.py
@@ -24,7 +24,7 @@ METHOD_DESC = {
 }
 
 
-def main(genebass_data: str) -> DataFrame:
+def main(spark: SparkSession, genebass_data: str) -> DataFrame:
     """
     This module extracts and processes target/disease evidence from the raw Genebass Portal.
     """
@@ -53,7 +53,7 @@ def main(genebass_data: str) -> DataFrame:
     )
 
     # Write output
-    evd_df = parse_genebass_evidence(genebass_df)
+    evd_df = parse_genebass_evidence(spark, genebass_df)
 
     if evd_df.filter(F.col("resourceScore") == 0).count() != 0:
         logging.exception("There are evidence with a P value of 0.")
@@ -70,7 +70,7 @@ def main(genebass_data: str) -> DataFrame:
     return evd_df
 
 
-def parse_genebass_evidence(genebass_df: DataFrame) -> DataFrame:
+def parse_genebass_evidence(spark: SparkSession, genebass_df: DataFrame) -> DataFrame:
     """
     Parse Genebass's disease/target evidence.
     Args:
@@ -132,7 +132,7 @@ def parse_genebass_evidence(genebass_df: DataFrame) -> DataFrame:
         .withColumnRenamed("description", "diseaseFromSource")
         .withColumnRenamed("phenocode", "diseaseFromSourceId")
         .join(
-            import_trait_mappings(),
+            import_trait_mappings(spark),
             on="diseaseFromSource",
             how="left",
         )
@@ -208,6 +208,7 @@ if __name__ == "__main__":
     spark = initialize_sparksession()
 
     evd_df = main(
+        spark=spark,
         genebass_data=args.genebass_data,
     )
 


### PR DESCRIPTION
This PR includes:
- fixes to the problem reported in [#2907](https://github.com/opentargets/issues/issues/2907), where the disease mappings path was hardcoded to the 22.09 release. We now build the path from the project's config YAML
- Spark instance manipulation is no longer handled inside `import_trait_mappings`. It is passed as a parameter instead

This was an important bug to solve because we were not using the most updated version of the disease mappings file.
Luckily, **this error had no impact**. It was only used by the Genebass, and AZ parsers and the curation for their evidence hasn't changed since 22.09.

I've tested it locally with a subset of data and it worked.