### PR TITLE
refactor (genetics parser): changing logic how QTLs processed

### DIFF
--- a/modules/GeneticsPortal.py
+++ b/modules/GeneticsPortal.py
@@ -466,19 +466,14 @@ def process_variant_rsid(variant_index: str):
 
 def write_evidence_strings(evidence_df: DataFrame, output_file: str) -> None:
     """Exports the table to a compressed JSON file containing the evidence strings."""
-    with tempfile.TemporaryDirectory() as tmp_dir_name:
-        (
-            evidence_df.coalesce(1)
-            .write.format("json")
-            .mode("overwrite")
-            .option("compression", "org.apache.hadoop.io.compress.GzipCodec")
-            .save(tmp_dir_name)
+    (
+        evidence_df.toPandas().to_json(
+            output_file,
+            orient="records",
+            lines=True,
+            compression="gzip",
         )
-        json_chunks = [f for f in os.listdir(tmp_dir_name) if f.endswith(".json.gz")]
-        assert (
-            len(json_chunks) == 1
-        ), f"Expected one JSON file, but found {len(json_chunks)}."
-        os.rename(os.path.join(tmp_dir_name, json_chunks[0]), output_file)
+    )
 
 
 def main(


### PR DESCRIPTION
Context: [#3287](https://github.com/opentargets/issues/issues/3287), [#3283](https://github.com/opentargets/issues/issues/3283)


The parser and the data is updated. The data is here:
```
gs://otar000-evidence_input/Genetics_portal/json/genetics-portal-evidence-2024-04-16.json.gz
```

## Benchmark against old data

**Questions:**

- Has the number of evidence changed?
- Has the number of evidence with directionality assignment changed?
- How many evidence have different QTL effect?
- How many times did the directionality changed?

**Answers:**

- There's no change in the number of evidence: 811,749
- Verified that the schema of the two datasets is the same.
- The number of evidence with directionality assessment dropped 12% to 210,050, which means 25.8% of evidence have directionality.
- Then number of evidence, where the directionality assignment changed is 67,170 representing ~31% of all evidence with directionality.