### PR TITLE
refactor(Gene2Phenotype): making code agnosting about the number of panels provided

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -31,6 +31,7 @@ ALL_FILES = [
     ('EyeG2P.csv.gz', GS.remote(f"{config['Gene2Phenotype']['inputBucket']}/EyeG2P-{timeStamp}.csv.gz")),
     ('SkinG2P.csv.gz', GS.remote(f"{config['Gene2Phenotype']['inputBucket']}/SkinG2P-{timeStamp}.csv.gz")),
     ('CancerG2P.csv.gz', GS.remote(f"{config['Gene2Phenotype']['inputBucket']}/CancerG2P-{timeStamp}.csv.gz")),
+    ('SkeletalG2P.csv.gz', GS.remote(f"{config['Gene2Phenotype']['inputBucket']}/SkeletalG2P-{timeStamp}.csv.gz")),
     ('pd_export_01_2023_probes_standardized.xlsx', GS.remote(f"{config['ChemicalProbes']['inputBucket']}/pd_export_01_2023_probes_standardized-{timeStamp}.xlsx")),
     ('pd_export_01_2023_links_standardized.csv', GS.remote(f"{config['ChemicalProbes']['inputBucket']}/pd_export_01_2023_links_standardized-{timeStamp}.csv")),
     ('intogen.json.gz', GS.remote(f"{config['intOGen']['outputBucket']}/intogen-{timeStamp}.json.gz")),
@@ -254,7 +255,8 @@ rule gene2Phenotype:          # Processes four gene panels from Gene2Phenotype
         eyePanel = HTTP.remote(config['Gene2Phenotype']['webSource_eye_panel']),
         skinPanel = HTTP.remote(config['Gene2Phenotype']['webSource_skin_panel']),
         cancerPanel = HTTP.remote(config['Gene2Phenotype']['webSource_cancer_panel']),
-        cardiacPanel = HTTP.remote(config['Gene2Phenotype']['webSource_cardiac_panel'])
+        cardiacPanel = HTTP.remote(config['Gene2Phenotype']['webSource_cardiac_panel']),
+        skeletalPanel = HTTP.remote(config['Gene2Phenotype']['webSource_skeletal_panel'])
     params:
         cacheDir = config['global']['cacheDir'],
         schema = f"{config['global']['schema']}/schemas/disease_target_evidence.json"
@@ -264,6 +266,7 @@ rule gene2Phenotype:          # Processes four gene panels from Gene2Phenotype
         skinBucket = 'SkinG2P.csv.gz',
         cancerBucket = 'CancerG2P.csv.gz',
         cardiacBucket = 'CardiacG2P.csv.gz',
+        skeletalBucket = 'SkeletalG2P.csv.gz',
         evidenceFile = 'gene2phenotype.json.gz'
     log:
         'log/gene2Phenotype.log'
@@ -276,15 +279,11 @@ rule gene2Phenotype:          # Processes four gene panels from Gene2Phenotype
         cp {input.skinPanel} {output.skinBucket}
         cp {input.cancerPanel} {output.cancerBucket}
         cp {input.cardiacPanel} {output.cardiacBucket}
+        cp {input.skeletalPanel} {output.skeletalBucket}
         python modules/Gene2Phenotype.py \
-          --dd_panel {input.ddPanel} \
-          --eye_panel {input.eyePanel} \
-          --skin_panel {input.skinPanel} \
-          --cancer_panel {input.cancerPanel} \
-          --cardiac_panel {input.cardiacPanel} \
+          --panels {input.ddPanel} {input.eyePanel} {input.skinPanel} {input.cancerPanel} {input.cardiacPanel} {input.skeletalPanel} \
           --output_file {output.evidenceFile} \
           --cache_dir {params.cacheDir} \
-          --local
         opentargets_validator --schema {params.schema} {output.evidenceFile}
         """
 

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -44,6 +44,7 @@ Gene2Phenotype:
   webSource_skin_panel: https://www.ebi.ac.uk/gene2phenotype/downloads/SkinG2P.csv.gz
   webSource_cancer_panel: https://www.ebi.ac.uk/gene2phenotype/downloads/CancerG2P.csv.gz
   webSource_cardiac_panel: https://www.ebi.ac.uk/gene2phenotype/downloads/CardiacG2P.csv.gz
+  webSource_skeletal_panel: https://www.ebi.ac.uk/gene2phenotype/downloads/SkeletalG2P.csv.gz
   inputBucket: gs://otar000-evidence_input/Gene2Phenotype/data_files
   outputBucket: gs://otar000-evidence_input/Gene2Phenotype/json
 intOGen:

--- a/modules/Gene2Phenotype.py
+++ b/modules/Gene2Phenotype.py
@@ -6,7 +6,7 @@ import logging
 from collections import OrderedDict
 from typing import List, Optional
 
-from pyspark.sql import Column, DataFrame, SparkSession
+from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql import functions as f
 from pyspark.sql import types as t
 

--- a/modules/Gene2Phenotype.py
+++ b/modules/Gene2Phenotype.py
@@ -17,18 +17,6 @@ from common.evidence import (
 )
 from common.ontology import add_efo_mapping
 
-"""As of 2024.05, the following consequence terms are used in the G2P data:
-
-+-----------------------------------+
-|uncertain                          |
-|absent gene product                |
-|altered gene product structure     |
-|5_prime or 3_prime UTR mutation    |
-|increased gene product level       |
-|decreased gene product level       |
-|cis-regulatory or promotor mutation|
-+-----------------------------------+
-"""
 G2P_mutationCsq2functionalCsq = OrderedDict(
     [
         ("uncertain", "SO_0002220"),
@@ -53,7 +41,7 @@ def main(
     # Initialize spark session
     spark = initialize_sparksession()
 
-    # Logg the processed panels:
+    # Log the processed panels:
     for panel in gene2phenotype_panels:
         logger.info(f"Processing the following Gene2Phenotype panel: {panel}")
 


### PR DESCRIPTION
This PR includes:

- [x] One command line option to take a list of input files (for each panel).
- [x] Removed un-used command line option `--local`.
- [x] Pipeline configuration updated to include the skeletal g2p panel.
- [x] Snakemake rule updated accourdingly.
- [x] Slight refactor to improve code quality (eg. modularise command line parameters, using common function to initialise logging, properly reading multiline input with quoted text etc).
- [x] Consequence map updated with new, yet unused term.
- [x] Handling semicolon separated list of consequence terms. Picking most severe one to ensure schema consistency.

The generated evidence were successfully validated against the current evidence schema.