### PR TITLE
feat(burden): update AZ config to newer release + include associations from synonymous models

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -4,7 +4,7 @@ global:
   schema: https://raw.githubusercontent.com/opentargets/json_schema/2.6.1
   EFOVersion: v3.62.0
   cell_passport_file: https://cog.sanger.ac.uk/cmp/download/model_list_latest.csv.gz
-  curation_repo: https://raw.githubusercontent.com/opentargets/curation/24.03
+  curation_repo: https://raw.githubusercontent.com/opentargets/curation/24.06
 baselineExpression:
   gtexSourceDataPath: https://storage.googleapis.com/adult-gtex/bulk-gex/v8/rna-seq/GTEx_Analysis_2017-06-05_v8_RNASeQCv1.1.9_gene_median_tpm.gct.gz
   tissueNameToUberonMappingPath: mappings/biosystem/gtex_v8_tissues.tsv
@@ -33,8 +33,8 @@ Essentiality:
   depmap_tissue_mapping: mappings/biosystem/depmap_uberon_mapping.csv
   outputBucket: gs://otar000-evidence_input/Essentiality/json
 GeneBurden:
-  azPhewasBinary: gs://otar000-evidence_input/GeneBurden/data_files/azphewas-com-450k-phewas-binary
-  azPhewasQuantitative: gs://otar000-evidence_input/GeneBurden/data_files/azphewas-com-450k-phewas-quantitative
+  azPhewasBinary: gs://otar000-evidence_input/GeneBurden/data_files/azphewas-com-470k-phewas-binary
+  azPhewasQuantitative: gs://otar000-evidence_input/GeneBurden/data_files/azphewas-com-470k-phewas-quantitative
   curation: gene_burden/curated_evidence.tsv
   genebass: gs://otar000-evidence_input/GeneBurden/data_files/genebass_entries
   outputBucket: gs://otar000-evidence_input/GeneBurden/json

--- a/modules/AzGeneBurden.py
+++ b/modules/AzGeneBurden.py
@@ -24,6 +24,7 @@ METHOD_DESC = {
     'flexnonsynmtr': 'Burden test carried out with MTR-informed non synonymous variants with a MAF smaller than 0.01%.',
     'ptvraredmg': 'Burden test carried out with PTV or rare missense variants.',
     'rec': 'Burden test carried out with non-synonymous recessive variants with a MAF smaller than 1%.',
+    'syn': 'Burden test carried out with synonymous variants.',
 }
 
 
@@ -58,9 +59,6 @@ def main(spark: SparkSession, az_binary_data: str, az_quant_data: str) -> DataFr
         .repartition(20)
         .persist()
     )
-
-    # Filter out associations from the synonymous model used as a negative control
-    az_phewas_df = remove_false_positives(az_phewas_df)
 
     # WARNING: There are some associations with a p-value of 0.0 in the AstraZeneca PheWAS Portal.
     # This is a bug we still have to ellucidate and it might be due to a float overflow.


### PR DESCRIPTION
This PR closes https://github.com/opentargets/issues/issues/3313

It's pointing to the version of the curation repo that contains the new mappings.
We are also adding significant associations from the synonymous models to be aligned with other sources. These are just 71.