### PR TITLE
feat(burden): drop evidence on categorical traits

### DIFF
--- a/modules/GenebassGeneBurden.py
+++ b/modules/GenebassGeneBurden.py
@@ -35,6 +35,7 @@ def main(spark: SparkSession, genebass_data: str) -> DataFrame:
         SparkSession.getActiveSession()
         .read.parquet(genebass_data)
         .filter(F.col("Pvalue_Burden") <= 6.7e-7)
+        .filter(F.col("trait_type") != "categorical")
         .select(
             "gene_id",
             "annotation",


### PR DESCRIPTION
As suggested by a community user in this thread
https://community.opentargets.org/t/remove-all-category-based-analysis-of-genebass-from-opentargets-platform/1393

The example illustrated in the thread showed a positive association between IL33 pLoF and asthma that was derived from this evidence on this trait `Blood clot, DVT, bronchitis, emphysema, asthma, rhinitis, eczema, allergy diagnosed by doctor`, which is inaccurate because IL33 pLoF has a protective effect.
In sum, categorical traits collapse different phenotypes together that hinders the interpretation of the association and its direction of effect.

We'll need to assess the impact of this, although I don't expect it to be big. There are 139 traits, and I assume that most of the associations will be covered by other models.