### PR TITLE
feat: add links to the AZ evidence + other release things

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -229,6 +229,8 @@ rule geneBurden:              # Processes gene burden data from various burden a
     input:
         azPhewasBinary = GS.remote(config['GeneBurden']['azPhewasBinary']),
         azPhewasQuant = GS.remote(config['GeneBurden']['azPhewasQuantitative']),
+        azGenesLinks = GS.remote(config['GeneBurden']['azPhewasGenesLinks']),
+        azPhenoLinks = GS.remote(config['GeneBurden']['azPhewasPhenotypesLinks']),
         curation = HTTP.remote(f"{config['global']['curation_repo']}/{config['GeneBurden']['curation']}"),
         genebass = GS.remote(config['GeneBurden']['genebass']),
     output:
@@ -243,6 +245,8 @@ rule geneBurden:              # Processes gene burden data from various burden a
         python modules/GeneBurden.py \
             --az_binary_data {input.azPhewasBinary} \
             --az_quant_data {input.azPhewasQuant} \
+            --az_genes_links {input.azGenesLinks} \
+            --az_phenotypes_links {input.azPhenoLinks} \
             --curated_data {input.curation} \
             --genebass_data {input.genebass} \
             --output {output.evidenceFile}

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1,8 +1,8 @@
 global:
   logDir: gs://otar000-evidence_input/parser_logs
   cacheDir: cache_dir
-  schema: https://raw.githubusercontent.com/opentargets/json_schema/2.6.1
-  EFOVersion: v3.62.0
+  schema: https://raw.githubusercontent.com/opentargets/json_schema/2.7.3
+  EFOVersion: v3.65.0
   cell_passport_file: https://cog.sanger.ac.uk/cmp/download/model_list_latest.csv.gz
   curation_repo: https://raw.githubusercontent.com/opentargets/curation/24.06
 baselineExpression:

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -35,6 +35,8 @@ Essentiality:
 GeneBurden:
   azPhewasBinary: gs://otar000-evidence_input/GeneBurden/data_files/azphewas-com-470k-phewas-binary
   azPhewasQuantitative: gs://otar000-evidence_input/GeneBurden/data_files/azphewas-com-470k-phewas-quantitative
+  azPhewasGenesLinks: gs://otar000-evidence_input/GeneBurden/data_files/azphewas_com_genes_UK Biobank_470k.csv
+  azPhewasPhenotypesLinks: gs://otar000-evidence_input/GeneBurden/data_files/azphewas_com_phenotypes_UK Biobank_470k.csv
   curation: gene_burden/curated_evidence.tsv
   genebass: gs://otar000-evidence_input/GeneBurden/data_files/genebass_entries
   outputBucket: gs://otar000-evidence_input/GeneBurden/json

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -17,8 +17,8 @@ cancerBiomarkers:
   drugIndex: gs://open-targets-data-releases/22.11/output/etl/parquet/molecule
   outputBucket: gs://otar000-evidence_input/CancerBiomarkers/json
 ChEMBL:
-  evidence: gs://otar008-chembl/cttv008_10-08-2023.json.gz
-  stopReasonCategories: gs://otar000-evidence_input/ChEMBL/data_files/chembl_predictions-2023-08-11.json
+  evidence: gs://otar008-chembl/cttv008_17-05-2024.json.gz
+  stopReasonCategories: gs://otar000-evidence_input/ChEMBL/data_files/chembl_predictions-2024-05-20.json
   outputBucket: gs://otar000-evidence_input/ChEMBL/json
 ClinGen:
   webSource: https://search.clinicalgenome.org/kb/gene-validity/download

--- a/modules/AzGeneBurden.py
+++ b/modules/AzGeneBurden.py
@@ -10,51 +10,86 @@ from pyspark.sql.dataframe import DataFrame
 import pyspark.sql.functions as F
 import pyspark.sql.types as T
 
-from common.evidence import initialize_sparksession, import_trait_mappings, write_evidence_strings
+from common.evidence import (
+    initialize_sparksession,
+    import_trait_mappings,
+    write_evidence_strings,
+)
 
 METHOD_DESC = {
-    'ptv': 'Burden test carried out with PTVs with a MAF smaller than 0.1%.',
-    'ptv5pcnt': 'Burden test carried out with PTVs with a MAF smaller than 5%.',
-    'UR': 'Burden test carried out with ultra rare damaging variants (MAF ≈ 0%).',
-    'URmtr': 'Burden test carried out with MTR-informed ultra rare damaging variants (MAF ≈ 0%).',
-    'raredmg': 'Burden test carried out with rare missense variants with a MAF smaller than 0.005%.',
-    'raredmgmtr': 'Burden test carried out with MTR-informed rare missense variants with a MAF smaller than 0.005%.',
-    'flexdmg': 'Burden test carried out with damaging variants with a MAF smaller than 0.01%.',
-    'flexnonsyn': 'Burden test carried out with non synonymous variants with a MAF smaller than 0.01%.',
-    'flexnonsynmtr': 'Burden test carried out with MTR-informed non synonymous variants with a MAF smaller than 0.01%.',
-    'ptvraredmg': 'Burden test carried out with PTV or rare missense variants.',
-    'rec': 'Burden test carried out with non-synonymous recessive variants with a MAF smaller than 1%.',
-    'syn': 'Burden test carried out with synonymous variants.',
+    "ptv": "Burden test carried out with PTVs with a MAF smaller than 0.1%.",
+    "ptv5pcnt": "Burden test carried out with PTVs with a MAF smaller than 5%.",
+    "UR": "Burden test carried out with ultra rare damaging variants (MAF ≈ 0%).",
+    "URmtr": "Burden test carried out with MTR-informed ultra rare damaging variants (MAF ≈ 0%).",
+    "raredmg": "Burden test carried out with rare missense variants with a MAF smaller than 0.005%.",
+    "raredmgmtr": "Burden test carried out with MTR-informed rare missense variants with a MAF smaller than 0.005%.",
+    "flexdmg": "Burden test carried out with damaging variants with a MAF smaller than 0.01%.",
+    "flexnonsyn": "Burden test carried out with non synonymous variants with a MAF smaller than 0.01%.",
+    "flexnonsynmtr": "Burden test carried out with MTR-informed non synonymous variants with a MAF smaller than 0.01%.",
+    "ptvraredmg": "Burden test carried out with PTV or rare missense variants.",
+    "rec": "Burden test carried out with non-synonymous recessive variants with a MAF smaller than 1%.",
+    "syn": "Burden test carried out with synonymous variants.",
 }
 
 
-def main(spark: SparkSession, az_binary_data: str, az_quant_data: str) -> DataFrame:
+def get_az_release_version(gene_links: DataFrame) -> str:
+    """Extract the release version from the gene links file."""
+    return (
+        gene_links.select(
+            F.regexp_extract(
+                F.col("link"), r"https://azphewas.com/geneView/([^/]+)/", 1
+            ).alias("extracted_hash")
+        )
+        .limit(1)
+        .collect()[0]["extracted_hash"]
+    )
+
+
+def main(
+    spark: SparkSession,
+    az_binary_data: str,
+    az_quant_data: str,
+    az_genes_links: str,
+    az_phenotypes_links: str,
+) -> DataFrame:
     """
     This module extracts and processes target/disease evidence from the raw AstraZeneca PheWAS Portal.
     """
-    logging.info(f'File with the AZ PheWAS Portal binary traits associations: {az_binary_data}')
-    logging.info(f'File with the AZ PheWAS Portal quantitative traits associations: {az_quant_data}')
+    logging.info(
+        f"File with the AZ PheWAS Portal binary traits associations: {az_binary_data}"
+    )
+    logging.info(
+        f"File with the AZ PheWAS Portal quantitative traits associations: {az_quant_data}"
+    )
+    logging.info(f"File with the AZ PheWAS Portal gene links: {az_genes_links}")
+    logging.info(
+        f"File with the AZ PheWAS Portal phenotype links: {az_phenotypes_links}"
+    )
 
     # Load data
+    az_genes_links_df = spark.read.csv(
+        az_genes_links, header=False, schema="gene STRING, link STRING"
+    )
+    az_phenotypes_links_df = spark.read.csv(
+        az_phenotypes_links, header=False, schema="diseaseFromSource STRING, url STRING"
+    )
     az_phewas_df = (
-        spark
-        .read.parquet(az_binary_data)
+        spark.read.parquet(az_binary_data)
         # Renaming of some columns to match schemas of both binary and quantitative evidence
-        .withColumnRenamed('BinOddsRatioLCI', 'LCI')
-        .withColumnRenamed('BinOddsRatioUCI', 'UCI')
-        .withColumnRenamed('BinNcases', 'nCases')
-        .withColumnRenamed('BinQVcases', 'nCasesQV')
-        .withColumnRenamed('BinNcontrols', 'nControls')
+        .withColumnRenamed("BinOddsRatioLCI", "LCI")
+        .withColumnRenamed("BinOddsRatioUCI", "UCI")
+        .withColumnRenamed("BinNcases", "nCases")
+        .withColumnRenamed("BinQVcases", "nCasesQV")
+        .withColumnRenamed("BinNcontrols", "nControls")
         # Combine binary and quantitative evidence into one dataframe
         .unionByName(
-            spark
-            .read.parquet(az_quant_data)
-            .withColumn('nCases', F.col('nSamples'))
-            .withColumnRenamed('YesQV', 'nCasesQV'),
+            spark.read.parquet(az_quant_data)
+            .withColumn("nCases", F.col("nSamples"))
+            .withColumnRenamed("YesQV", "nCasesQV"),
             allowMissingColumns=True,
         )
-        .withColumn('pValue', F.col('pValue').cast(T.DoubleType()))
-        .filter(F.col('pValue') <= 1e-7)
+        .withColumn("pValue", F.col("pValue").cast(T.DoubleType()))
+        .filter(F.col("pValue") <= 1e-7)
         .distinct()
         .repartition(20)
         .persist()
@@ -64,25 +99,38 @@ def main(spark: SparkSession, az_binary_data: str, az_quant_data: str) -> DataFr
     # This is a bug we still have to ellucidate and it might be due to a float overflow.
     # These evidence need to be manually corrected in order not to lose them and for them to pass validation
     # As an interim solution, their p value will equal to the minimum in the evidence set.
-    logging.warning(f"There are {az_phewas_df.filter(F.col('pValue') == 0.0).count()} evidence with a p-value of 0.0.")
-    minimum_pvalue = az_phewas_df.filter(F.col('pValue') > 0.0).agg({'pValue': 'min'}).collect()[0]['min(pValue)']
+    logging.warning(
+        f"There are {az_phewas_df.filter(F.col('pValue') == 0.0).count()} evidence with a p-value of 0.0."
+    )
+    minimum_pvalue = (
+        az_phewas_df.filter(F.col("pValue") > 0.0)
+        .agg({"pValue": "min"})
+        .collect()[0]["min(pValue)"]
+    )
     az_phewas_df = az_phewas_df.withColumn(
-        'pValue', F.when(F.col('pValue') == 0.0, F.lit(minimum_pvalue)).otherwise(F.col('pValue'))
+        "pValue",
+        F.when(F.col("pValue") == 0.0, F.lit(minimum_pvalue)).otherwise(
+            F.col("pValue")
+        ),
     )
 
     # Write output
     evd_df = parse_az_phewas_evidence(spark, az_phewas_df)
 
-    if evd_df.filter(F.col('resourceScore') == 0).count() != 0:
-        logging.error('There are evidence with a P value of 0.')
+    if evd_df.filter(F.col("resourceScore") == 0).count() != 0:
+        logging.error("There are evidence with a P value of 0.")
         raise AssertionError(
             f"There are {evd_df.filter(F.col('resourceScore') == 0).count()} evidence with a P value of 0."
         )
 
     if not 17_000 < evd_df.count() < 19_000:
-        logging.error(f'AZ PheWAS Portal number of evidence are different from expected: {evd_df.count()}')
-        raise AssertionError('AZ PheWAS Portal number of evidence are different from expected.')
-    logging.info(f'{evd_df.count()} evidence strings have been processed.')
+        logging.error(
+            f"AZ PheWAS Portal number of evidence are different from expected: {evd_df.count()}"
+        )
+        raise AssertionError(
+            "AZ PheWAS Portal number of evidence are different from expected."
+        )
+    logging.info(f"{evd_df.count()} evidence strings have been processed.")
 
     return evd_df
 
@@ -90,103 +138,135 @@ def main(spark: SparkSession, az_binary_data: str, az_quant_data: str) -> DataFr
 def remove_false_positives(az_phewas_df: DataFrame) -> DataFrame:
     """Remove associations present in the synonymous negative control."""
 
-    false_positives = az_phewas_df.filter(F.col('CollapsingModel') == 'syn').select('Gene', 'Phenotype').distinct()
-    true_positives = az_phewas_df.join(false_positives, on=['Gene', 'Phenotype'], how='left_anti').distinct()
+    false_positives = (
+        az_phewas_df.filter(F.col("CollapsingModel") == "syn")
+        .select("Gene", "Phenotype")
+        .distinct()
+    )
+    true_positives = az_phewas_df.join(
+        false_positives, on=["Gene", "Phenotype"], how="left_anti"
+    ).distinct()
     logging.info(
-        f'{az_phewas_df.count() - true_positives.count()} false positive evidence of association have been dropped.'
+        f"{az_phewas_df.count() - true_positives.count()} false positive evidence of association have been dropped."
     )
 
     return true_positives
 
 
-def parse_az_phewas_evidence(spark: SparkSession, az_phewas_df: DataFrame) -> DataFrame:
+def parse_az_phewas_evidence(
+    spark: SparkSession,
+    az_phewas_df: DataFrame,
+    az_genes_links_df: DataFrame,
+    az_phenotypes_links_df: DataFrame,
+) -> DataFrame:
     """
     Parse Astra Zeneca's PheWAS Portal evidence.
     Args:
         az_phewas_df: DataFrame with Astra Zeneca's PheWAS Portal data
+        az_genes_links_df: DataFrame with Astra Zeneca's gene links that we use to extract the hash of the release version
+        az_phenotypes_links_df: DataFrame with Astra Zeneca's phenotype links that we use to extract the url
     Returns:
         evd_df: DataFrame with Astra Zeneca's data following the t/d evidence schema.
     """
     to_keep = [
-        'datasourceId',
-        'datatypeId',
-        'allelicRequirements',
-        'targetFromSourceId',
-        'diseaseFromSource',
-        'diseaseFromSourceMappedId',
-        'pValueMantissa',
-        'pValueExponent',
-        'beta',
-        'betaConfidenceIntervalLower',
-        'betaConfidenceIntervalUpper',
-        'oddsRatio',
-        'oddsRatioConfidenceIntervalLower',
-        'oddsRatioConfidenceIntervalUpper',
-        'resourceScore',
-        'ancestry',
-        'ancestryId',
-        'literature',
-        'projectId',
-        'cohortId',
-        'studySampleSize',
-        'studyCases',
-        'studyCasesWithQualifyingVariants',
-        'statisticalMethod',
-        'statisticalMethodOverview',
+        "datasourceId",
+        "datatypeId",
+        "allelicRequirements",
+        "targetFromSourceId",
+        "diseaseFromSource",
+        "diseaseFromSourceMappedId",
+        "pValueMantissa",
+        "pValueExponent",
+        "beta",
+        "betaConfidenceIntervalLower",
+        "betaConfidenceIntervalUpper",
+        "oddsRatio",
+        "oddsRatioConfidenceIntervalLower",
+        "oddsRatioConfidenceIntervalUpper",
+        "resourceScore",
+        "ancestry",
+        "ancestryId",
+        "literature",
+        "projectId",
+        "cohortId",
+        "releaseVersion",
+        "studySampleSize",
+        "studyCases",
+        "studyCasesWithQualifyingVariants",
+        "statisticalMethod",
+        "statisticalMethodOverview",
+        "urls",
     ]
 
     return (
-        az_phewas_df.withColumn('datasourceId', F.lit('gene_burden'))
-        .withColumn('datatypeId', F.lit('genetic_association'))
-        .withColumn('literature', F.array(F.lit('34375979')))
-        .withColumn('projectId', F.lit('AstraZeneca PheWAS Portal'))
-        .withColumn('cohortId', F.lit('UK Biobank 450k'))
-        .withColumnRenamed('Gene', 'targetFromSourceId')
-        .withColumnRenamed('Phenotype', 'diseaseFromSource')
+        az_phewas_df.withColumn("datasourceId", F.lit("gene_burden"))
+        .withColumn("datatypeId", F.lit("genetic_association"))
+        .withColumn("literature", F.array(F.lit("34375979")))
+        .withColumn("projectId", F.lit("AstraZeneca PheWAS Portal"))
+        .withColumn("cohortId", F.lit("UK Biobank 450k"))
+        .withColumnRenamed("Gene", "targetFromSourceId")
+        .withColumnRenamed("Phenotype", "diseaseFromSource")
         .join(
             import_trait_mappings(spark),
-            on='diseaseFromSource',
-            how='left',
+            on="diseaseFromSource",
+            how="left",
         )
-        .withColumn('resourceScore', F.col('pValue'))
-        .withColumn('pValueExponent', F.log10(F.col('pValue')).cast(T.IntegerType()) - F.lit(1))
-        .withColumn('pValueMantissa', F.round(F.col('pValue') / F.pow(F.lit(10), F.col('pValueExponent')), 3))
+        .withColumn("resourceScore", F.col("pValue"))
         .withColumn(
-            'beta',
-            F.when(F.col('Type') == 'Quantitative', F.col('beta')),
+            "pValueExponent", F.log10(F.col("pValue")).cast(T.IntegerType()) - F.lit(1)
         )
         .withColumn(
-            'betaConfidenceIntervalLower',
-            F.when(F.col('Type') == 'Quantitative', F.col('LCI')),
+            "pValueMantissa",
+            F.round(F.col("pValue") / F.pow(F.lit(10), F.col("pValueExponent")), 3),
         )
         .withColumn(
-            'betaConfidenceIntervalUpper',
-            F.when(F.col('Type') == 'Quantitative', F.col('UCI')),
+            "beta",
+            F.when(F.col("Type") == "Quantitative", F.col("beta")),
         )
         .withColumn(
-            'oddsRatio',
-            F.when(F.col('Type') == 'Binary', F.col('binOddsRatio')),
+            "betaConfidenceIntervalLower",
+            F.when(F.col("Type") == "Quantitative", F.col("LCI")),
         )
         .withColumn(
-            'oddsRatioConfidenceIntervalLower',
-            F.when(F.col('Type') == 'Binary', F.col('LCI')),
+            "betaConfidenceIntervalUpper",
+            F.when(F.col("Type") == "Quantitative", F.col("UCI")),
         )
         .withColumn(
-            'oddsRatioConfidenceIntervalUpper',
-            F.when(F.col('Type') == 'Binary', F.col('UCI')),
+            "oddsRatio",
+            F.when(F.col("Type") == "Binary", F.col("binOddsRatio")),
         )
-        .withColumn('ancestry', F.lit('EUR'))
-        .withColumn('ancestryId', F.lit('HANCESTRO_0005'))
-        .withColumnRenamed('nSamples', 'studySampleSize')
-        .withColumnRenamed('nCases', 'studyCases')
-        .withColumnRenamed('nCasesQV', 'studyCasesWithQualifyingVariants')
-        .withColumnRenamed('CollapsingModel', 'statisticalMethod')
-        .withColumn('statisticalMethodOverview', F.col('statisticalMethod'))
-        .replace(to_replace=METHOD_DESC, subset=['statisticalMethodOverview'])
         .withColumn(
-            'allelicRequirements',
-            F.when(F.col('statisticalMethod') == 'rec', F.array(F.lit('recessive'))).otherwise(
-                F.array(F.lit('dominant'))
+            "oddsRatioConfidenceIntervalLower",
+            F.when(F.col("Type") == "Binary", F.col("LCI")),
+        )
+        .withColumn(
+            "oddsRatioConfidenceIntervalUpper",
+            F.when(F.col("Type") == "Binary", F.col("UCI")),
+        )
+        .withColumn("ancestry", F.lit("EUR"))
+        .withColumn("ancestryId", F.lit("HANCESTRO_0005"))
+        .withColumnRenamed("nSamples", "studySampleSize")
+        .withColumnRenamed("nCases", "studyCases")
+        .withColumnRenamed("nCasesQV", "studyCasesWithQualifyingVariants")
+        .withColumnRenamed("CollapsingModel", "statisticalMethod")
+        .withColumn("statisticalMethodOverview", F.col("statisticalMethod"))
+        .replace(to_replace=METHOD_DESC, subset=["statisticalMethodOverview"])
+        .withColumn(
+            "allelicRequirements",
+            F.when(
+                F.col("statisticalMethod") == "rec", F.array(F.lit("recessive"))
+            ).otherwise(F.array(F.lit("dominant"))),
+        )
+        .withColumn("releaseVersion", F.lit(get_az_release_version(az_genes_links_df)))
+        # Add urls to the phenotypes
+        .join(az_phenotypes_links_df, on="diseaseFromSource", how="left")
+        .withColumn(
+            "urls",
+            F.array(
+                F.struct(
+                    F.lit("AstraZeneca PheWAS Portal").alias("niceName"),
+                    F.col("url").alias("url"),
+                )
             ),
         )
         .select(to_keep)
@@ -195,46 +275,58 @@ def parse_az_phewas_evidence(spark: SparkSession, az_phewas_df: DataFrame) -> Da
 
 
 def get_parser():
-    'Get parser object for script AzGeneBurden.py.'
+    "Get parser object for script AzGeneBurden.py."
     parser = argparse.ArgumentParser(description=__doc__)
 
     parser.add_argument(
-        '--az_binary_data',
-        help='Input parquet files with AZ\'s PheWAS associations of binary traits.',
+        "--az_binary_data",
+        help="Input parquet files with AZ's PheWAS associations of binary traits.",
         type=str,
         required=True,
     )
     parser.add_argument(
-        '--az_quant_data',
-        help='Input parquet files with AZ\'s PheWAS associations of quantitative traits.',
+        "--az_quant_data",
+        help="Input parquet files with AZ's PheWAS associations of quantitative traits.",
         type=str,
         required=True,
     )
     parser.add_argument(
-        '--output',
-        help='Output gzipped json file following the gene_burden evidence data model.',
+        "--az_genes_links",
+        help="Input CSV file that consists of a look up table between a gene and its link in the AZ Phewas Portal.",
         type=str,
         required=True,
     )
     parser.add_argument(
-        '--log_file',
-        help='Destination of the logs generated by this script. Defaults to None',
+        "--az_phenotypes_links",
+        help="Input CSV file that consists of a look up table between a phenotype and its link in the AZ Phewas Portal.",
         type=str,
-        nargs='?',
+        required=True,
+    )
+    parser.add_argument(
+        "--output",
+        help="Output gzipped json file following the gene_burden evidence data model.",
+        type=str,
+        required=True,
+    )
+    parser.add_argument(
+        "--log_file",
+        help="Destination of the logs generated by this script. Defaults to None",
+        type=str,
+        nargs="?",
         default=None,
     )
 
     return parser
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     args = get_parser().parse_args()
 
     # Logger initializer. If no log_file is specified, logs are written to stderr
     logging.basicConfig(
         level=logging.INFO,
-        format='%(asctime)s %(levelname)s %(module)s - %(funcName)s: %(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S',
+        format="%(asctime)s %(levelname)s %(module)s - %(funcName)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
     )
     if args.log_file:
         logging.config.fileConfig(filename=args.log_file)
@@ -247,7 +339,9 @@ if __name__ == '__main__':
         spark=spark,
         az_binary_data=args.az_binary_data,
         az_quant_data=args.az_quant_data,
+        az_genes_links=args.az_genes_links,
+        az_phenotypes_links=args.az_phenotypes_links,
     )
 
     write_evidence_strings(evd_df, args.output)
-    logging.info(f'Evidence strings have been saved to {args.output}. Exiting.')
+    logging.info(f"Evidence strings have been saved to {args.output}. Exiting.")

--- a/modules/AzGeneBurden.py
+++ b/modules/AzGeneBurden.py
@@ -115,7 +115,7 @@ def main(
     )
 
     # Write output
-    evd_df = parse_az_phewas_evidence(spark, az_phewas_df)
+    evd_df = parse_az_phewas_evidence(spark, az_phewas_df, az_genes_links_df, az_phenotypes_links_df)
 
     if evd_df.filter(F.col("resourceScore") == 0).count() != 0:
         logging.error("There are evidence with a P value of 0.")

--- a/modules/GeneBurden.py
+++ b/modules/GeneBurden.py
@@ -75,7 +75,7 @@ def process_gene_burden_curation(spark: SparkSession, curated_data: str) -> Data
         # 4. Add hardcoded values and drop URLs (will be handled by the FE) and HGNC symbols
         .withColumn('datasourceId', F.lit('gene_burden'))
         .withColumn('datatypeId', F.lit('genetic_association'))
-        .drop('url', 'targetFromSource')
+        .drop('url', 'targetFromSource', 'studyId')
         .distinct()
     )
 

--- a/modules/GeneBurden.py
+++ b/modules/GeneBurden.py
@@ -21,6 +21,8 @@ def main(
     spark: SparkSession,
     az_binary_data: str,
     az_quant_data: str,
+    az_genes_links: str,
+    az_phenotypes_links: str,
     curated_data: str,
     genebass_data: str,
 ) -> DataFrame:
@@ -28,7 +30,7 @@ def main(
 
     burden_evidence_sets = [
         # Generate evidence from AZ data:
-        process_az_gene_burden(spark, az_binary_data, az_quant_data).persist(),
+        process_az_gene_burden(spark, az_binary_data, az_quant_data, az_genes_links, az_phenotypes_links).persist(),
         # Generate evidence from manual data:
         process_gene_burden_curation(spark, curated_data).persist(),
         # Generate evidence from GeneBass data:
@@ -135,6 +137,18 @@ def get_parser():
         required=True,
     )
     parser.add_argument(
+        "--az_genes_links",
+        help="Input CSV file that consists of a look up table between a gene and its link in the AZ Phewas Portal.",
+        type=str,
+        required=True,
+    )
+    parser.add_argument(
+        "--az_phenotypes_links",
+        help="Input CSV file that consists of a look up table between a phenotype and its link in the AZ Phewas Portal.",
+        type=str,
+        required=True,
+    )
+    parser.add_argument(
         '--curated_data',
         help='Input remote CSV file containing the gene burden manual curation.',
         type=str,
@@ -183,6 +197,8 @@ if __name__ == "__main__":
         spark=spark,
         az_binary_data=args.az_binary_data,
         az_quant_data=args.az_quant_data,
+        az_genes_links=args.az_genes_links,
+        az_phenotypes_links=args.az_phenotypes_links,
         curated_data=args.curated_data,
         genebass_data=args.genebass_data,
     )


### PR DESCRIPTION
This PR includes:
- Changes to the gene burden evidence:
    - New field `releaseVersion`, only present for AZ evidence, containing their release hash. This is extracted from a LUT they have provided with links between genes and their gene pages.
    - New field `urls`, only present for AZ evidence, containing a link to their traits page. This is extracted from another provided LUT.
    - `studyId` has been dropped. This field only contained GCST IDs for the REGENERON evidence. Even though the GWASCat team helped us in providing trait mappings, this information is empty for 80% of evidence. Together with @buniello and @d0choa, we have agreed to drop this field from the UI
- Updated ChEMBL files
- Pinned EFO version to 3.65.0 and schema version to 2.7.3 (the latest release is 2.7.2 but i have to create another one to reflect the changes in the burden schema)