### PR TITLE
chore: prepare 24.06 release

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -287,7 +287,7 @@ rule gene2Phenotype:          # Processes four gene panels from Gene2Phenotype
         python modules/Gene2Phenotype.py \
           --panels {input.ddPanel} {input.eyePanel} {input.skinPanel} {input.cancerPanel} {input.cardiacPanel} {input.skeletalPanel} \
           --output_file {output.evidenceFile} \
-          --cache_dir {params.cacheDir} \
+          --cache_dir {params.cacheDir}
         opentargets_validator --schema {params.schema} {output.evidenceFile}
         """
 

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -85,8 +85,8 @@ TargetSafety:
   aopwiki: gs://otar001-core/TargetSafety/data_files/aopwiki/aopwiki-2023-01-20.json
   outputBucket: gs://otar001-core/TargetSafety/json
 ChemicalProbes:
-  probesExcelDump: https://www.probes-drugs.org/media/download/probes/pd_export_02_2023_probes_standardized.xlsx
-  probesMappingsTable: https://www.probes-drugs.org/media/download/id_mapping/pd_export_02_2023_links_standardized.csv
+  probesExcelDump: https://www.probes-drugs.org/media/download/probes/pd_export_01_2024_probes_standardized.xlsx
+  probesMappingsTable: https://www.probes-drugs.org/media/download/id_mapping/pd_export_01_2024_links_standardized.csv
   inputBucket: gs://otar001-core/ChemicalProbes/data_files
   outputBucket: gs://otar001-core/ChemicalProbes/annotation
 OT_CRISPR:

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -35,8 +35,8 @@ Essentiality:
 GeneBurden:
   azPhewasBinary: gs://otar000-evidence_input/GeneBurden/data_files/azphewas-com-470k-phewas-binary
   azPhewasQuantitative: gs://otar000-evidence_input/GeneBurden/data_files/azphewas-com-470k-phewas-quantitative
-  azPhewasGenesLinks: gs://otar000-evidence_input/GeneBurden/data_files/azphewas_com_genes_UK Biobank_470k.csv
-  azPhewasPhenotypesLinks: gs://otar000-evidence_input/GeneBurden/data_files/azphewas_com_phenotypes_UK Biobank_470k.csv
+  azPhewasGenesLinks: gs://otar000-evidence_input/GeneBurden/data_files/azphewas_com_genes_UK_Biobank_470k.csv
+  azPhewasPhenotypesLinks: gs://otar000-evidence_input/GeneBurden/data_files/azphewas_com_phenotypes_UK_Biobank_470k.csv
   curation: gene_burden/curated_evidence.tsv
   genebass: gs://otar000-evidence_input/GeneBurden/data_files/genebass_entries
   outputBucket: gs://otar000-evidence_input/GeneBurden/json

--- a/modules/AzGeneBurden.py
+++ b/modules/AzGeneBurden.py
@@ -221,33 +221,35 @@ def parse_az_phewas_evidence(
         )
         .withColumn(
             "beta",
-            F.when(F.col("Type") == "Quantitative", F.col("beta")),
+            F.when(F.col("Type") == "Quantitative", F.col("beta")).cast("float"),
         )
         .withColumn(
             "betaConfidenceIntervalLower",
-            F.when(F.col("Type") == "Quantitative", F.col("LCI")),
+            F.when(F.col("Type") == "Quantitative", F.col("LCI")).cast("float"),
         )
         .withColumn(
             "betaConfidenceIntervalUpper",
-            F.when(F.col("Type") == "Quantitative", F.col("UCI")),
+            F.when(F.col("Type") == "Quantitative", F.col("UCI")).cast("float"),
         )
         .withColumn(
             "oddsRatio",
-            F.when(F.col("Type") == "Binary", F.col("binOddsRatio")),
+            F.when(F.col("Type") == "Binary", F.col("binOddsRatio")).cast("float"),
         )
         .withColumn(
             "oddsRatioConfidenceIntervalLower",
-            F.when(F.col("Type") == "Binary", F.col("LCI")),
+            F.when(F.col("Type") == "Binary", F.col("LCI")).cast("float"),
         )
         .withColumn(
             "oddsRatioConfidenceIntervalUpper",
-            F.when(F.col("Type") == "Binary", F.col("UCI")),
+            F.when(F.col("Type") == "Binary", F.col("UCI")).cast("float"),
         )
         .withColumn("ancestry", F.lit("EUR"))
         .withColumn("ancestryId", F.lit("HANCESTRO_0005"))
-        .withColumnRenamed("nSamples", "studySampleSize")
-        .withColumnRenamed("nCases", "studyCases")
-        .withColumnRenamed("nCasesQV", "studyCasesWithQualifyingVariants")
+        .withColumn("studySampleSize", F.col("nSamples").cast("int"))
+        .withColumn("studyCases", F.col("nCases").cast("int"))
+        .withColumn(
+            "studyCasesWithQualifyingVariants", F.col("nCasesQV").cast("int")
+        )
         .withColumnRenamed("CollapsingModel", "statisticalMethod")
         .withColumn("statisticalMethodOverview", F.col("statisticalMethod"))
         .replace(to_replace=METHOD_DESC, subset=["statisticalMethodOverview"])

--- a/modules/AzGeneBurden.py
+++ b/modules/AzGeneBurden.py
@@ -123,7 +123,7 @@ def main(
             f"There are {evd_df.filter(F.col('resourceScore') == 0).count()} evidence with a P value of 0."
         )
 
-    if not 17_000 < evd_df.count() < 19_000:
+    if not 28_000 < evd_df.count() < 30_000:
         logging.error(
             f"AZ PheWAS Portal number of evidence are different from expected: {evd_df.count()}"
         )

--- a/modules/AzGeneBurden.py
+++ b/modules/AzGeneBurden.py
@@ -203,7 +203,7 @@ def parse_az_phewas_evidence(
         .withColumn("datatypeId", F.lit("genetic_association"))
         .withColumn("literature", F.array(F.lit("34375979")))
         .withColumn("projectId", F.lit("AstraZeneca PheWAS Portal"))
-        .withColumn("cohortId", F.lit("UK Biobank 450k"))
+        .withColumn("cohortId", F.lit("UK Biobank 470k"))
         .withColumnRenamed("Gene", "targetFromSourceId")
         .withColumnRenamed("Phenotype", "diseaseFromSource")
         .join(
@@ -266,8 +266,8 @@ def parse_az_phewas_evidence(
             "urls",
             F.array(
                 F.struct(
-                    F.lit("AstraZeneca PheWAS Portal").alias("niceName"),
                     F.col("url").alias("url"),
+                    F.lit("AstraZeneca PheWAS Portal").alias("niceName"),
                 )
             ),
         )

--- a/modules/ChEMBL.py
+++ b/modules/ChEMBL.py
@@ -44,11 +44,11 @@ def main(chembl_evidence: str, predictions: str, output_file: str) -> None:
     )
 
     # We expect that ~10% of evidence strings have a reason to stop assigned
-    # It is asserted that this fraction is between 9 and 11% of the total count
+    # It is asserted that this fraction is between 9 and 15% of the total count
     total_count = chembl_df.count()
     early_stopped_count = early_stopped_evd_df.count()
 
-    if not 0.08 < early_stopped_count / total_count < 0.11:
+    if not 0.08 < early_stopped_count / total_count < 0.15:
         raise AssertionError(f'The fraction of evidence with a CT reason to stop class is not as expected ({early_stopped_count / total_count}).')
 
     logging.info('Evidence strings have been processed. Saving...')


### PR DESCRIPTION
Small changes that fix minor issues to generate data for the 24.06 release.

## Evidence Metrics
![image](https://github.com/opentargets/evidence_datasource_parsers/assets/45119610/766c2601-9710-4e27-bc04-d7426edfed51)

No red flags, I reckon. I think the CRISPR drop is only because the 24.03 didn’t include your modifications.
- G2P: +492 after the inclusion of the skeletal panel
- Panel App: +1845 with the new version. I think they have improved their disease annotation, because we now have **+2502 evidence with a mapped disease**.
- EVA somatic: -32, slight drop. I'll take a look.
- EVA: +370605. You'll be pleased to know that we have a lot of new variants 😬 (37% increase), probably worth looking with more detail. I'll look at the slight drop in the somatic evidnce.
- ChEMBL: +53791 with data from ChEMBL34. We have evidence for 55 new drugs.
- Burden: +9613 with the update of the AZ Phewas evidence. Here the number of genes is virtually the same, but we have increased the number of diseases mapped by a third.
- 

## Probes and Drugs update
We're now up to date with the latest release of P&D with 63 new probes (a total of 5130)


