### PR TITLE
fix(chembl): update stopReasonCategories file

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -18,7 +18,7 @@ cancerBiomarkers:
   outputBucket: gs://otar000-evidence_input/CancerBiomarkers/json
 ChEMBL:
   evidence: gs://otar008-chembl/cttv008_2024-08-09.json.gz
-  stopReasonCategories: gs://otar000-evidence_input/ChEMBL/data_files/chembl_predictions-2024-05-20.json
+  stopReasonCategories: gs://otar000-evidence_input/ChEMBL/data_files/chembl_predictions-2024-08-12.json
   outputBucket: gs://otar000-evidence_input/ChEMBL/json
 ClinGen:
   webSource: https://search.clinicalgenome.org/kb/gene-validity/download


### PR DESCRIPTION
This PR:
- updates the path to the predicted stopped reasons based on the latest ChEMBL evidence
- adds a mechanism to the ChEMBL parser that raises an error if the file with the predictions is older than the evidence file

I've generated new evidence, and the evidence step in PIS has rerun.