### PR TITLE
Changes made to enable running parsers for 24.12 release

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -527,7 +527,8 @@ rule encore:                  # Generating PPP evidence for ENCORE
     params:
         data_folder = config['Encore']['data_directory'],
         config = config['Encore']['config'],
-        schema = f"{config['global']['schema']}/schemas/disease_target_evidence.json"
+        schema = f"{config['global']['schema']}/schemas/disease_target_evidence.json",
+	cell_line_to_uberon_mapping = f"{config['global']['curation_repo']}/{config['Essentiality']['depmap_tissue_mapping']}"
     output:
         'encore.json.gz'
     input:
@@ -537,11 +538,17 @@ rule encore:                  # Generating PPP evidence for ENCORE
     shell:
         """
         exec &> {log}
+
+	# Fetching data from bucket to home folder:
+	mkdir -p ~/encore_data
+	gsutil -m cp -r "{params.data_folder}/*" ~/encore_data/
+
         python partner_preview_scripts/encore_parser.py \
             --output_file {output} \
             --parameter_file {params.config} \
-            --data_folder {params.data_folder} \
-            --cell_passport_file {input.cell_passport_table}
+            --data_folder ~/encore_data \
+            --cell_passport_file {input.cell_passport_table} \
+	    --cell_line_to_uberon_mapping {params.cell_line_to_uberon_mapping}
         opentargets_validator --schema {params.schema} {output}
         """
 

--- a/Snakefile
+++ b/Snakefile
@@ -48,9 +48,9 @@ ALL_FILES = [
     ('crispr_screens.json.gz', GS.remote(f"{config['CrisprScreens']['outputBucket']}/crispr_screens-{timeStamp}.json.gz")),
     ('pharmacogenetics.json.gz', GS.remote(f"{config['Pharmacogenetics']['outputBucket']}/cttv012-{timeStamp}_pgkb.json.gz")),
     # PPP specific parsers:
-    ('ot_crispr.json.gz', GS.remote(f"{config['OT_CRISPR']['outputBucket']}/ot_crispr-{timeStamp}.json.gz")),
-    ('validation_lab.json.gz', GS.remote(f"{config['ValidationLab']['outputBucket']}/validation_lab-{timeStamp}.json.gz")),
-    ('encore.json.gz', GS.remote(f"{config['Encore']['outputBucket']}/encore-{timeStamp}.json.gz"))
+    #('ot_crispr.json.gz', GS.remote(f"{config['OT_CRISPR']['outputBucket']}/ot_crispr-{timeStamp}.json.gz")),
+    #('validation_lab.json.gz', GS.remote(f"{config['ValidationLab']['outputBucket']}/validation_lab-{timeStamp}.json.gz")),
+    #('encore.json.gz', GS.remote(f"{config['Encore']['outputBucket']}/encore-{timeStamp}.json.gz"))
 ]
 LOCAL_FILENAMES = [f[0] for f in ALL_FILES]
 REMOTE_FILENAMES = [f[1] for f in ALL_FILES]

--- a/Snakefile
+++ b/Snakefile
@@ -566,9 +566,14 @@ rule validation_lab:          # Generating PPP evidence for Validation Lab
     shell:
         """
         exec &> {log}
+
+	# Fetching data from bucket to home folder:
+        mkdir -p ~/validation_lab_data
+        gsutil -m cp -r "{params.data_folder}/*" ~/validation_lab_data/
+
         python partner_preview_scripts/ValidationLab.py \
             --parameter_file {params.config} \
-            --data_folder {params.data_folder} \
+            --data_folder ~/validation_lab_data \
             --cell_passport_file {input.cell_passport_table} \
             --output_file {output}
         opentargets_validator --schema {params.schema} {output}

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -101,7 +101,7 @@ ValidationLab:
   config: gs://otar013-ppp/PPP-evidence-configuration/ValidationLab_config.json
   outputBucket: gs://otar013-ppp/validation_lab
 Encore:
-  data_directory: gs://otar013-ppp/encore/input
+  data_directory: gs://otar013-ppp/encore/input/2024.01.11-Freeze4
   config: gs://otar013-ppp/PPP-evidence-configuration/encore_config.json
   outputBucket: gs://otar013-ppp/encore
 CrisprScreens:

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1,7 +1,7 @@
 global:
   logDir: gs://otar000-evidence_input/parser_logs
   cacheDir: cache_dir
-  schema: https://raw.githubusercontent.com/opentargets/json_schema/2.8.0
+  schema: https://raw.githubusercontent.com/opentargets/json_schema/2.8.1
   EFOVersion: v3.68.0
   cell_passport_file: https://cog.sanger.ac.uk/cmp/download/model_list_latest.csv.gz
   curation_repo: https://raw.githubusercontent.com/opentargets/curation/24.09.1

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -4,7 +4,7 @@ global:
   schema: https://raw.githubusercontent.com/opentargets/json_schema/2.8.1
   EFOVersion: v3.68.0
   cell_passport_file: https://cog.sanger.ac.uk/cmp/download/model_list_latest.csv.gz
-  curation_repo: https://raw.githubusercontent.com/opentargets/curation/24.09.1
+  curation_repo: https://raw.githubusercontent.com/opentargets/curation/24.12
 baselineExpression:
   gtexSourceDataPath: https://storage.googleapis.com/adult-gtex/bulk-gex/v8/rna-seq/GTEx_Analysis_2017-06-05_v8_RNASeQCv1.1.9_gene_median_tpm.gct.gz
   tissueNameToUberonMappingPath: mappings/biosystem/gtex_v8_tissues.tsv

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1,7 +1,7 @@
 global:
   logDir: gs://otar000-evidence_input/parser_logs
   cacheDir: cache_dir
-  schema: https://raw.githubusercontent.com/opentargets/json_schema/2.8.1
+  schema: https://raw.githubusercontent.com/opentargets/json_schema/2.8.2
   EFOVersion: v3.71.0
   cell_passport_file: https://cog.sanger.ac.uk/cmp/download/model_list_latest.csv.gz
   curation_repo: https://raw.githubusercontent.com/opentargets/curation/24.12

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -2,7 +2,7 @@ global:
   logDir: gs://otar000-evidence_input/parser_logs
   cacheDir: cache_dir
   schema: https://raw.githubusercontent.com/opentargets/json_schema/2.8.1
-  EFOVersion: v3.68.0
+  EFOVersion: v3.71.0
   cell_passport_file: https://cog.sanger.ac.uk/cmp/download/model_list_latest.csv.gz
   curation_repo: https://raw.githubusercontent.com/opentargets/curation/24.12
 baselineExpression:

--- a/modules/IMPC.py
+++ b/modules/IMPC.py
@@ -111,7 +111,7 @@ class IMPC:
     """Retrieve the data, load it into Spark, process and write the resulting evidence strings."""
 
     # Human gene mappings.
-    HGNC_DATASET_URI = 'http://ftp.ebi.ac.uk/pub/databases/genenames/hgnc/tsv/hgnc_complete_set.txt'
+    HGNC_DATASET_URI = 'https://storage.googleapis.com/public-download-files/hgnc/tsv/tsv/hgnc_complete_set.txt'
     HGNC_DATASET_FILENAME = 'hgnc_complete_set.txt'
 
     # Mouse gene mappings.

--- a/partner_preview_scripts/encore_parser.py
+++ b/partner_preview_scripts/encore_parser.py
@@ -514,13 +514,13 @@ class EncoreEvidenceGenerator:
         return evidence_df
 
 
-def main(outputFile: str, parameters: dict, cellPassportFile: str) -> None:
+def main(outputFile: str, parameters: dict, cellPassportFile: str, cellLineToUberonMapping: str) -> None:
 
     # Initialize spark session
     spark = initialize_sparksession()
 
     # Opening and parsing the cell passport data from Sanger:
-    cell_passport_df = GenerateDiseaseCellLines(cellPassportFile, spark).get_mapping()
+    cell_passport_df = GenerateDiseaseCellLines(spark, cellPassportFile, cellLineToUberonMapping).generate_disease_cell_lines()
 
     logging.info(f"Cell passport dataframe has {cell_passport_df.count()} rows.")
     logging.info("Parsing experiment data...")
@@ -581,6 +581,12 @@ if __name__ == "__main__":
         help="File containing cell passport data",
         required=True,
     )
+    parser.add_argument(
+        "--cell_line_to_uberon_mapping",
+        type=str,
+        help="Path to the manual curation file for mapping cell lines to uberon terms.",
+        required=True,
+    )
     args = parser.parse_args()
 
     # If no logfile is specified, logs are written to the standard error:
@@ -606,4 +612,4 @@ if __name__ == "__main__":
     parameters["sharedMetadata"]["data_folder"] = args.data_folder
 
     # Passing all the required arguments:
-    main(args.output_file, parameters, args.cell_passport_file)
+    main(args.output_file, parameters, args.cell_passport_file, args.cell_line_to_uberon_mapping)

--- a/partner_preview_scripts/encore_parser.py
+++ b/partner_preview_scripts/encore_parser.py
@@ -272,7 +272,7 @@ class EncoreEvidenceGenerator:
                 # Based on the z-score we can tell the nature of the interaction:
                 # - positive z-score means synergictic
                 # - negative z-score means antagonistics interaction
-                f.when(f.col("geneticInteractionScore") > 0, "synergistic")
+                f.when(f.col("geneticInteractionScore") > 0, "cooperative")
                 .otherwise("antagonistic")
                 .alias("geneInteractionType"),
             )

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -91,6 +91,7 @@ reretry==0.11.8
 retry2==0.9.5
 rpds-py==0.20.0
 rsa==4.9
+scipy==1.10.1
 six==1.16.0
 smart-open==7.0.4
 smmap==5.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ pronto==2.5.3
 pyspark==3.3.1
 requests==2.32.0
 retry2==0.9.5
+scipy==1.10.1
 snakemake==7.20.0
 openai==1.8
 PuLP==2.7.0


### PR DESCRIPTION
This PR updates the schema, curation, and EFO versions for the 24.12 release.

scipy (needed for the encore parser) was added to the requirements.

Changes were made to the IMPC, encore, and validation lab parsers.