### PR TITLE
feat: update chemical probes to P&D 02.2024 release

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -88,8 +88,8 @@ TargetSafety:
   brennan: gs://otar001-core/TargetSafety/data_files/brennan/secondary_pharmacology.json
   outputBucket: gs://otar001-core/TargetSafety/json
 ChemicalProbes:
-  probesExcelDump: pd_export_01_2024_probes_standardized.xlsx
-  probesMappingsTable: pd_export_01_2024_links_standardized.csv
+  probesExcelDump: pd_export_02_2024_probes_standardized.xlsx
+  probesMappingsTable: pd_export_02_2024_links_standardized.csv
   inputBucket: gs://otar001-core/ChemicalProbes/data_files
   outputBucket: gs://otar001-core/ChemicalProbes/annotation
 OT_CRISPR:

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -63,7 +63,6 @@ opentargets-validator==1.0.0
 pandarallel==1.6.4
 pandas==1.5.3
 pathos==0.3.2
-pkg_resources==0.0.0
 pkgutil_resolve_name==1.3.10
 plac==1.4.3
 platformdirs==4.2.2


### PR DESCRIPTION
This PR closes https://github.com/opentargets/issues/issues/3485

The new files have brought us 93 new probe/target annotation (an increase of 62 new unique compounds). We should expect information for 27 targets not covered previously, [CES1](https://platform.opentargets.org/target/ENSG00000198848) being an example.

Data available here: `gs://otar001-core/ChemicalProbes/annotation/chemicalProbes-2025-01-10.json.gz`


_Side note:_ I had to delete `pkg_resources==0.0.0` from the lock file because pip was failing with `ERROR: No matching distribution found for pkg_resources==0.0.0`
