### PR TITLE
build: upgrade yarl to fix environment conflict

### DIFF
--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -106,6 +106,6 @@ typing_extensions==4.12.2
 uritemplate==4.1.1
 urllib3==2.2.2
 wrapt==1.16.0
-yarl==1.9.4
+yarl==1.15.2
 yte==1.5.4
 zipp==3.19.2


### PR DESCRIPTION
This is a minor fix. The PGx evidence was failing because the environment was not properly set up (OpenAI was failing with [this error](https://community.openai.com/t/error-with-openai-1-56-0-client-init-got-an-unexpected-keyword-argument-proxies/1040332/2)).

I have fixed the environment so that `pip3 install -r requirements-frozen.txt` correctly sets up all dependencies. The changes in the pgx are only minor.