### PR TITLE
chore: updating PanelApp input file

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -63,7 +63,7 @@ Orphanet:
   webSource: http://www.orphadata.org/data/xml/en_product6.xml
   outputBucket: gs://otar000-evidence_input/Orphanet/json
 PanelApp:
-  inputAssociationsTable: gs://otar000-evidence_input/GenomicsEngland/data_files/PanelApp_genes_all_ratings_public_v1plus_2024-11-28.tsv
+  inputAssociationsTable: gs://otar000-evidence_input/GenomicsEngland/data_files/All_genes_20250525_public_v1plus_genes_all_ratings.tsv
   outputBucket: gs://otar000-evidence_input/GenomicsEngland/json
 IMPC:
   evidenceOutputBucket: gs://otar000-evidence_input/IMPC/json


### PR DESCRIPTION
As of 25th May,  a new GenomicsEngland Panel App data is available. The dataset (coming in excel), got converted to tsv and moved to our buckets. A test run made sure the data is compatible with the old release and the resulting evidence dataset is valid. and shows a moderate increase.